### PR TITLE
fix(core): record tool input/output on v2 spans under an explicit capture policy

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -538,8 +538,24 @@ so no high-cardinality run/task/tenant/request fields become metric labels.
 The adapter exports no prompt, completion, tool arguments/results, raw payload,
 credential, chain-of-thought, or reasoning content. Numeric token counts remain
 eligible. It forwards only an explicit low-sensitivity `oma.*` allowlist rather
-than arbitrary record attributes. `contentCapture` is a reserved disabled-only extension point; there
-is no content-capture switch in this release.
+than arbitrary record attributes.
+
+`contentCapture` opens one bounded exception. Under
+`contentCapture: { mode: 'upstream-policy' }` the adapter also forwards
+`oma.tool.input` and `oma.tool.output`, which core produces only when
+`observability.capture` opts in and `SensitiveDataProcessor` has already
+redacted and truncated. Both opt-ins are required: the adapter setting alone
+exports nothing extra, because without the core policy those attributes are
+never recorded. No other content attribute is eligible under any mode, and
+reasoning content has no opt-in at all. The default remains
+`mode: 'disabled'`.
+
+`service.name` comes from the Resource on the application's own
+`TracerProvider`. The adapter never sets it, so a provider built without a
+Resource reports OMA spans under the OTel default (`unknown_service:node`).
+`metadata.release` and `metadata.environment` map to `service.version` and
+`deployment.environment.name` as span attributes; they are not a substitute for
+a Resource.
 
 The first release intentionally provides no OTLP convenience subpath. The
 application selects its own OTel SDK and OTLP/exporter implementation, avoiding
@@ -785,6 +801,24 @@ only core-controlled content opt-in. Structured credential fields are removed
 even when content capture is enabled. Chain-of-thought/reasoning content,
 signed reasoning blocks, and `<thinking>` text are never captured by OMA
 instrumentation; numeric reasoning-token counts may be recorded.
+
+Setting `toolInput` or `toolOutput` to `'redacted'` makes tool spans carry
+`oma.tool.input` and `oma.tool.output`:
+
+```typescript
+const orchestrator = new OpenMultiAgent({
+  observability: {
+    sinks: [sink],
+    capture: { toolInput: 'redacted', toolOutput: 'redacted' },
+  },
+})
+```
+
+The remaining fields are filters, not producers. `prompt` and `completion`
+currently gate content that no v2 instrumentation site emits, so setting them
+records nothing; they exist so a custom sink's own attributes are filtered
+consistently. Legacy `onTrace` is unaffected by this policy and keeps its
+own redacted fields.
 
 Legacy `onTrace` keeps its existing redacted tool input/output fields for
 compatibility, so its privacy surface is intentionally broader than the v2

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -320,6 +320,20 @@ function extractText(content: readonly ContentBlock[]): string {
     .join('')
 }
 
+/**
+ * Render tool arguments as a single span attribute. Trace attributes are
+ * scalars, so an object argument has to become text; a value that cannot be
+ * serialized is reported rather than failing the tool call.
+ */
+function stringifyToolContent(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value) ?? String(value)
+  } catch {
+    return '[unserializable tool input]'
+  }
+}
+
 /** Extract every ToolUseBlock from a content array. */
 function extractToolUseBlocks(content: readonly ContentBlock[]): ToolUseBlock[] {
   return content.filter((b): b is ToolUseBlock => b.type === 'tool_use')
@@ -1927,10 +1941,19 @@ export class AgentRunner implements AgentBackend {
       const classified = isError
         ? classifyRunFailure(new Error(recordedOutput), { kind: 'tool' })
         : undefined
+      // Tool input/output reach v2 spans only under an explicit capture
+      // policy. `SensitiveDataProcessor` still redacts and truncates these
+      // values; serializing here is skipped entirely when the policy is off.
+      const contentAttributes = options.traceRuntime?.capturesToolIO
+        ? {
+            'oma.tool.input': stringifyToolContent(redactSensitiveObject(block.input)),
+            'oma.tool.output': redactSensitiveText(summarizeToolResultContent(modelOutput)),
+          }
+        : undefined
       toolSpan.end({
         status: classified?.status ?? { code: 'ok' },
         ...(classified ? { error: classified.errorInfo } : {}),
-        attributes: { 'oma.tool.is_error': isError },
+        attributes: { 'oma.tool.is_error': isError, ...contentAttributes },
         ...(legacyEvent ? { legacyEvent } : {}),
       })
       toolSpan.ensureEnded()

--- a/packages/core/src/observability/runtime.ts
+++ b/packages/core/src/observability/runtime.ts
@@ -81,6 +81,13 @@ function safeEmit(sink: TraceSink | undefined, record: TraceRecord): void {
 export class TraceRuntime {
   readonly identity: RunIdentity
   readonly root: TraceSpan
+  /**
+   * True when the configured capture policy opts into tool input/output.
+   * Instrumentation sites read this before serializing content they would
+   * otherwise build and immediately discard; `SensitiveDataProcessor` still
+   * performs the authoritative filtering and redaction.
+   */
+  readonly capturesToolIO: boolean
   private sequence = 0
   private readonly sink?: TraceSink
 
@@ -90,8 +97,10 @@ export class TraceRuntime {
     legacyCallback?: (event: TraceEvent) => void | Promise<void>,
     sink?: TraceSink,
     rootAttributes: Readonly<Record<string, TraceAttributeValue>> = {},
+    capturesToolIO = false,
   ) {
     this.identity = identity
+    this.capturesToolIO = capturesToolIO
     const legacySink = legacyCallback && legacyCallback !== LEGACY_TRACE_METADATA_ONLY
       ? new LegacyCallbackTraceSink(legacyCallback)
       : undefined
@@ -258,8 +267,9 @@ export function createTraceRuntime(
   observer?: TraceRecordObserver,
   sink?: TraceSink,
   rootAttributes?: Readonly<Record<string, TraceAttributeValue>>,
+  capturesToolIO?: boolean,
 ): TraceRuntime | undefined {
   return legacyCallback || observer || sink
-    ? new TraceRuntime(identity, observer, legacyCallback, sink, rootAttributes)
+    ? new TraceRuntime(identity, observer, legacyCallback, sink, rootAttributes, capturesToolIO)
     : undefined
 }

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -457,6 +457,7 @@ export class OpenMultiAgent {
   private completedTaskCount = 0
   private readonly traceRecordObserver?: TraceRecordObserver
   private readonly traceSink?: TraceSink
+  private readonly traceCapturesToolIO: boolean
   private readonly onlineEvaluator?: OnlineEvaluator
   /** Online evaluation lifecycle. A shared no-op facade is returned when disabled. */
   readonly evaluation: OnlineEvaluationLifecycle
@@ -498,6 +499,11 @@ export class OpenMultiAgent {
           sinkName: 'OpenMultiAgent',
         })
       : undefined
+    // Instrumentation only pays to serialize tool content when the policy
+    // admits it. Both fields default to 'none', so the default run is
+    // byte-for-byte what it was before this opt-in existed.
+    this.traceCapturesToolIO = config.observability?.capture?.toolInput === 'redacted'
+      || config.observability?.capture?.toolOutput === 'redacted'
     this.config = {
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
       maxDelegationDepth: config.maxDelegationDepth ?? DEFAULT_MAX_DELEGATION_DEPTH,
@@ -878,6 +884,7 @@ export class OpenMultiAgent {
       this.traceRecordObserver,
       this.traceSink,
       metadataAttributes(metadata, metadataOverridden),
+      this.traceCapturesToolIO,
     )
   }
 

--- a/packages/core/tests/observability-v2-privacy.test.ts
+++ b/packages/core/tests/observability-v2-privacy.test.ts
@@ -78,4 +78,77 @@ describe('Observability v2 default privacy boundary', () => {
     })
     await sink.shutdown({ timeoutMs: 500 })
   })
+
+  it('admits tool input/output under an explicit capture policy without widening other content', async () => {
+    let call = 0
+    const adapter: LLMAdapter = {
+      name: 'privacy-test',
+      async chat() { return call++ === 0 ? toolCall() : completion() },
+      async *stream() {},
+    }
+    const tool = defineTool({
+      name: 'private_lookup',
+      description: 'Privacy test tool.',
+      inputSchema: z.object({ query: z.string() }),
+      execute: async () => ({ data: TOOL_RESULT }),
+    })
+    const store = new InMemoryTraceStore()
+    const sink = new BatchingTraceSink(new TraceStoreExporter(store), {
+      diagnostics: 'silent',
+      scheduledDelayMs: 60_000,
+    })
+    const result = await new OpenMultiAgent({
+      observability: {
+        sinks: [sink],
+        capture: { toolInput: 'redacted', toolOutput: 'redacted' },
+      },
+    }).runAgent({
+      name: 'worker',
+      model: 'privacy-test',
+      adapter,
+      customTools: [tool],
+    }, PROMPT)
+
+    expect(result.success).toBe(true)
+    await expect(sink.forceFlush({ timeoutMs: 500 })).resolves.toMatchObject({ status: 'ok' })
+    const stored = await store.getRun(result.identity!.runId, { includeRecords: true })
+    const toolEnd = stored?.records?.find((record) =>
+      record.recordType === 'span_end' && record.attributes?.['oma.tool.name'] === 'private_lookup')
+
+    // The opted-in fields arrive.
+    expect(toolEnd?.attributes?.['oma.tool.input']).toContain(TOOL_ARGUMENT)
+    expect(toolEnd?.attributes?.['oma.tool.output']).toContain(TOOL_RESULT)
+
+    // Everything the policy did not name stays out, including reasoning, which
+    // has no opt-in at all.
+    const serialized = JSON.stringify(stored?.records)
+    for (const secret of [PROMPT, COMPLETION, REASONING]) {
+      expect(serialized).not.toContain(secret)
+    }
+    expect(serialized).not.toContain('<thinking>')
+    await sink.shutdown({ timeoutMs: 500 })
+  })
+
+  it('leaves tool spans untouched when the capture policy names neither tool field', async () => {
+    const adapter: LLMAdapter = {
+      name: 'privacy-test',
+      async chat() { return completion() },
+      async *stream() {},
+    }
+    const store = new InMemoryTraceStore()
+    const sink = new BatchingTraceSink(new TraceStoreExporter(store), {
+      diagnostics: 'silent',
+      scheduledDelayMs: 60_000,
+    })
+    // A policy that opts into unrelated fields must not switch tool capture on.
+    const result = await new OpenMultiAgent({
+      observability: { sinks: [sink], capture: { errorMessage: 'redacted' } },
+    }).runAgent({ name: 'worker', model: 'privacy-test', adapter }, PROMPT)
+
+    expect(result.success).toBe(true)
+    await expect(sink.forceFlush({ timeoutMs: 500 })).resolves.toMatchObject({ status: 'ok' })
+    const stored = await store.getRun(result.identity!.runId, { includeRecords: true })
+    expect(JSON.stringify(stored?.records)).not.toContain('oma.tool.input')
+    await sink.shutdown({ timeoutMs: 500 })
+  })
 })

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -133,11 +133,32 @@ Prompt, completion, tool arguments/results, raw payloads, credentials, and
 reasoning/chain-of-thought content are filtered by default. The adapter uses an
 explicit low-sensitivity `oma.*` allowlist rather than forwarding arbitrary
 record attributes. This includes `<thinking>` and provider reasoning content.
-Token counts remain eligible for
-export. `contentCapture` is a reserved type-level extension point whose only
-accepted value is `mode: 'disabled'`; there is intentionally no content-capture
-switch in this release. Applications that need such a feature must add an
-explicit, separately reviewed capture policy upstream of the adapter.
+Token counts remain eligible for export.
+
+`contentCapture` accepts `mode: 'disabled'` (the default) and
+`mode: 'upstream-policy'`. Under `upstream-policy` the adapter additionally
+forwards `oma.tool.input` and `oma.tool.output`, and nothing else:
+
+```typescript
+const sink = createOtelTraceSink({
+  tracerProvider: provider,
+  contentCapture: { mode: 'upstream-policy' },
+})
+```
+
+That mode defers to the capture policy upstream of the adapter rather than
+introducing one here. Core records those two attributes only when
+`observability.capture` sets `toolInput`/`toolOutput`, and only after
+`SensitiveDataProcessor` has stripped structured credentials, redacted the
+text, and truncated it to `maxContentChars`. Enabling the adapter mode without
+the core policy exports nothing extra, because the attributes do not exist.
+Reasoning and chain-of-thought content have no opt-in under any mode.
+
+`service.name` belongs to the Resource on the application's `TracerProvider`.
+This adapter never sets it; a provider built without a Resource reports OMA
+spans under the OTel default (`unknown_service:node`). `metadata.release` and
+`metadata.environment` are span attributes (`service.version`,
+`deployment.environment.name`) and do not replace a Resource.
 
 ## OTLP convenience decision
 

--- a/packages/otel/src/exporter.ts
+++ b/packages/otel/src/exporter.ts
@@ -83,7 +83,14 @@ export interface OTelMetadata {
 }
 
 export interface OTelContentCaptureExtension {
-  readonly mode?: 'disabled'
+  /**
+   * `disabled` (default) exports no content-bearing attribute. Under
+   * `upstream-policy` the adapter forwards the bounded set of content
+   * attributes that core produces only when `observability.capture` opts in,
+   * already redacted and truncated by `SensitiveDataProcessor`. Both opt-ins
+   * are required, so this alone never widens what a run records.
+   */
+  readonly mode?: 'disabled' | 'upstream-policy'
 }
 
 export interface OTelTraceSinkOptions extends OTelTraceExporterOptions {
@@ -145,14 +152,21 @@ export class OTelTraceExporter implements TraceExporter {
   private readonly recentRootContexts = new Map<string, SpanContext>()
   private readonly shutdownOnShutdown: boolean
   private readonly metadata: Attributes
+  private readonly allowUpstreamContent: boolean
 
   constructor(private readonly options: OTelTraceExporterOptions) {
     if ((options.tracer === undefined) === (options.tracerProvider === undefined)) {
       throw new TypeError('Provide exactly one of tracer or tracerProvider; global OpenTelemetry state is never used.')
     }
-    if (options.contentCapture?.mode !== undefined && options.contentCapture.mode !== 'disabled') {
-      throw new TypeError('Content capture is not implemented by @open-multi-agent/otel.')
+    if (options.contentCapture?.mode !== undefined
+      && options.contentCapture.mode !== 'disabled'
+      && options.contentCapture.mode !== 'upstream-policy') {
+      throw new TypeError(
+        'Unsupported contentCapture mode for @open-multi-agent/otel. '
+        + "Use 'disabled' (default) or 'upstream-policy'.",
+      )
     }
+    this.allowUpstreamContent = options.contentCapture?.mode === 'upstream-policy'
     this.provider = options.tracerProvider
     this.tracer = options.tracer ?? options.tracerProvider!.getTracer(
       options.instrumentationName ?? '@open-multi-agent/otel',
@@ -271,7 +285,7 @@ export class OTelTraceExporter implements TraceExporter {
       this.openSpans.set(key, entry)
     }
     entry.span.setAttributes({
-      ...spanAttributes(record),
+      ...spanAttributes(record, this.allowUpstreamContent),
       ...this.metadata,
       'oma.status': record.status.code,
     })
@@ -308,7 +322,7 @@ export class OTelTraceExporter implements TraceExporter {
     // active at export time; batching makes that ambient context arbitrary.
     const parentContext = parent ? trace.setSpanContext(ROOT_CONTEXT, parent) : ROOT_CONTEXT
     const attributes: Attributes = {
-      ...spanAttributes(record),
+      ...spanAttributes(record, this.allowUpstreamContent),
       ...this.metadata,
       ...(incomplete ? { 'oma.record.incomplete': true } : {}),
     }
@@ -322,7 +336,7 @@ export class OTelTraceExporter implements TraceExporter {
   }
 
   private safeEventAttributes(record: SpanEventRecord): Attributes {
-    return mapOmaAttributes(record.attributes)
+    return mapOmaAttributes(record.attributes, this.allowUpstreamContent)
   }
 
   private addEndLinks(entry: SpanEntry, links: readonly TraceLink[] | undefined): void {

--- a/packages/otel/src/mapping.ts
+++ b/packages/otel/src/mapping.ts
@@ -84,20 +84,37 @@ function isTokenUsageAttribute(key: string): boolean {
   return key.startsWith('oma.usage.') && (key.endsWith('_tokens') || key.endsWith('.tokens'))
 }
 
-/** OMA content is never exported by this package; only an explicit safe metadata allowlist crosses the boundary. */
-export function isSafeOmaAttribute(key: string): boolean {
+/**
+ * Content attributes that core only produces under an explicit
+ * `observability.capture` policy, and that this package forwards only when the
+ * application also opts in with `contentCapture: { mode: 'upstream-policy' }`.
+ * Both opt-ins are required; neither alone exports content.
+ */
+const UPSTREAM_POLICY_CONTENT_ATTRIBUTES = new Set([
+  'oma.tool.input',
+  'oma.tool.output',
+])
+
+/**
+ * OMA content crosses this boundary only through the safe metadata allowlist,
+ * or through `UPSTREAM_POLICY_CONTENT_ATTRIBUTES` when the caller has opted
+ * into the upstream capture policy.
+ */
+export function isSafeOmaAttribute(key: string, allowUpstreamContent = false): boolean {
   if (!key.startsWith('oma.')) return false
   if (isTokenUsageAttribute(key)) return true
+  if (allowUpstreamContent && UPSTREAM_POLICY_CONTENT_ATTRIBUTES.has(key)) return true
   if (CONTENT_ATTRIBUTE.test(key) || SECRET_ATTRIBUTE.test(key)) return false
   return SAFE_OMA_ATTRIBUTES.has(key)
 }
 
 export function mapOmaAttributes(
   attributes: Readonly<Record<string, TraceAttributeValue>>,
+  allowUpstreamContent = false,
 ): Attributes {
   const mapped: Attributes = {}
   for (const [key, value] of Object.entries(attributes)) {
-    if (isSafeOmaAttribute(key)) mapped[key] = toAttributeValue(value)
+    if (isSafeOmaAttribute(key, allowUpstreamContent)) mapped[key] = toAttributeValue(value)
   }
   return mapped
 }
@@ -210,11 +227,14 @@ export function baseAttributes(record: TraceRecordBase & { readonly recordType: 
   }
 }
 
-export function spanAttributes(record: SpanStartRecord | SpanEndRecord): Attributes {
+export function spanAttributes(
+  record: SpanStartRecord | SpanEndRecord,
+  allowUpstreamContent = false,
+): Attributes {
   const attributes: Attributes = {
     ...baseAttributes(record),
     'oma.span.kind': record.kind,
-    ...mapOmaAttributes(record.attributes),
+    ...mapOmaAttributes(record.attributes, allowUpstreamContent),
   }
   addGenAiAttributes(record.kind, attributes)
   return attributes

--- a/packages/otel/tests/otel-exporter.test.ts
+++ b/packages/otel/tests/otel-exporter.test.ts
@@ -505,6 +505,58 @@ describe('@open-multi-agent/otel', () => {
     expect(JSON.stringify(span.attributes)).not.toMatch(/private|credential|chain of thought|raw request|unclassified/)
   })
 
+  it('forwards upstream-policy tool content only when the caller opts in, and never widens other content', async () => {
+    const toolAttributes = {
+      'oma.tool.name': 'echo_tool',
+      'oma.tool.input': '{"payload":"tool input body"}',
+      'oma.tool.output': 'tool output body',
+      // Still refused under the opt-in: these are not upstream-policy fields.
+      'oma.prompt': 'private prompt',
+      'oma.completion': 'private completion',
+      'oma.tool.arguments': '{"credential":"do-not-export"}',
+      'oma.reasoning.content': 'chain of thought',
+    }
+
+    const off = inMemory()
+    await exportRecords(createOtelTraceExporter({ tracerProvider: off.provider }), [
+      start('3'.repeat(15) + 'a', 'execute_tool', 'tool', { attributes: toolAttributes }),
+      end('3'.repeat(15) + 'a', 'execute_tool', 'tool', { attributes: toolAttributes }),
+    ])
+    const defaultSpan = off.exporter.getFinishedSpans()[0]!
+    expect(defaultSpan.attributes['oma.tool.name']).toBe('echo_tool')
+    expect(defaultSpan.attributes['oma.tool.input']).toBeUndefined()
+    expect(defaultSpan.attributes['oma.tool.output']).toBeUndefined()
+
+    const on = inMemory()
+    await exportRecords(
+      createOtelTraceExporter({
+        tracerProvider: on.provider,
+        contentCapture: { mode: 'upstream-policy' },
+      }),
+      [
+        start('4'.repeat(15) + 'a', 'execute_tool', 'tool', { attributes: toolAttributes }),
+        end('4'.repeat(15) + 'a', 'execute_tool', 'tool', { attributes: toolAttributes }),
+      ],
+    )
+    const optedInSpan = on.exporter.getFinishedSpans()[0]!
+    expect(optedInSpan.attributes['oma.tool.input']).toBe('{"payload":"tool input body"}')
+    expect(optedInSpan.attributes['oma.tool.output']).toBe('tool output body')
+    expect(JSON.stringify(optedInSpan.attributes))
+      .not.toMatch(/private prompt|private completion|credential|chain of thought/)
+  })
+
+  it('rejects an unsupported contentCapture mode', () => {
+    const { provider } = inMemory()
+    expect(() => createOtelTraceExporter({
+      tracerProvider: provider,
+      contentCapture: { mode: 'everything' as 'disabled' },
+    })).toThrow(TypeError)
+    expect(() => createOtelTraceExporter({
+      tracerProvider: provider,
+      contentCapture: { mode: 'disabled' },
+    })).not.toThrow()
+  })
+
   it('reports duplicate, out-of-order, and incomplete records without throwing or exporting content', async () => {
     const { exporter, provider } = inMemory()
     const diagnostics: string[] = []


### PR DESCRIPTION
## Problem

Tool arguments and results reach the legacy `onTrace` callback but never reach v2 sinks, so moving from `onTrace` to `observability.sinks` silently drops data the old callback provided. Anyone exporting to an OpenTelemetry backend sees tool spans with a name and an error flag and nothing about what the tool was called with or what it returned.

`TraceCapturePolicy` already declared `toolInput` and `toolOutput`, and `SensitiveDataProcessor` already filtered on them, but no instrumentation site produced the attributes. Both switches were inert: setting them to `'redacted'` changed nothing.

Measured on one run with both channels attached:

```
               | tool INPUT | tool OUTPUT
legacy onTrace | true       | true
v2 sink        | false      | false     <- with capture set to 'redacted'
```

## Change

`AgentRunner` attaches `oma.tool.input` and `oma.tool.output` to the `execute_tool` span when the capture policy opts in. `TraceRuntime.capturesToolIO` carries that decision down so the serialization is skipped entirely when the policy is off, keeping unopted runs byte-for-byte identical to before. Values are redacted at the instrumentation site as well as in the processor, so a `TraceRuntime` built outside the orchestrator does not bypass redaction.

```typescript
const orchestrator = new OpenMultiAgent({
  observability: {
    sinks: [sink],
    capture: { toolInput: 'redacted', toolOutput: 'redacted' },
  },
})
```

`@open-multi-agent/otel` gains `contentCapture: { mode: 'upstream-policy' }`, which forwards those two attributes and nothing else. This is the separately reviewed upstream policy that the package's reserved extension point was waiting for, rather than a second capture policy inside the adapter. Both opt-ins are required: enabling the adapter mode alone exports nothing extra, because without the core policy the attributes are never recorded. Prompt, completion, raw payload, credential, and reasoning content stay excluded under every mode.

## Docs

The capture policy section now says which fields have producers. `prompt` and `completion` remain filters over attributes that no v2 site emits, so setting them still records nothing, and the docs no longer imply otherwise.

Also recorded: `service.name` comes from the Resource on the application's own `TracerProvider`. The adapter never sets it, so a provider built without a Resource reports OMA spans under the OTel default. `metadata.release` and `metadata.environment` are span attributes and are not a substitute for a Resource.

## Verification

Full suite green: core 2029, create-oma-app 31, otel 17, release-bot 48. Lint and build pass in every workspace.

New tests cover the opt-in producing both attributes, an unrelated capture field not switching tool capture on, the adapter refusing to forward content by default, and an unsupported `contentCapture` mode still throwing.

Beyond the unit tests, this was verified against a real OTLP/HTTP exporter posting to a local collector, which is the path an OpenTelemetry user actually takes rather than `InMemorySpanExporter`. With no opt-in the wire payload contains no tool content. With both opt-ins the `execute_tool` span carries `oma.tool.input` and `oma.tool.output`, and no other content attribute appears.

## Scope

`prompt` and `completion` still have no producer. The legacy callback does not carry them either, so that is not a regression, and adding them would widen the privacy surface rather than restore lost behavior. Left for a separate decision.
