### PR TITLE
feat(examples): add an adaptive-recovery capability to the catalog

### DIFF
--- a/packages/core/examples/catalog.json
+++ b/packages/core/examples/catalog.json
@@ -80,7 +80,7 @@
       "description": "Repair a typed evidence gap with targeted archive lookups, or stop at a real recovery limit and fail closed to manual review, while retaining truthful task history.",
       "section": "goal",
       "goal": "use-case-recipes",
-      "capabilities": ["run-tasks", "task-dependencies", "structured-output"],
+      "capabilities": ["run-tasks", "adaptive-recovery", "task-dependencies", "structured-output"],
       "format": "script",
       "level": "intermediate"
     },

--- a/packages/core/examples/catalog.schema.json
+++ b/packages/core/examples/catalog.schema.json
@@ -23,6 +23,7 @@
     "capability": {
       "enum": [
         "acp",
+        "adaptive-recovery",
         "agent-pool",
         "ai-sdk",
         "conflict-detection",

--- a/scripts/example-catalog-lib.mjs
+++ b/scripts/example-catalog-lib.mjs
@@ -15,6 +15,7 @@ export const EXAMPLE_GOALS = [
 
 export const EXAMPLE_CAPABILITIES = [
   'acp',
+  'adaptive-recovery',
   'agent-pool',
   'ai-sdk',
   'conflict-detection',


### PR DESCRIPTION
## Summary

The example catalog's controlled vocabulary had no term for runtime plan repair. `cookbook/commission-reconciliation-recovery` is the only example that runs `recovery: { mode: 'repairable' }`, but it was filed under `run-tasks`, `task-dependencies`, and `structured-output`, so browsing or filtering the catalog by capability could not lead anyone to it. This adds `adaptive-recovery` to the vocabulary and tags that example with it.

## Motivation

Adaptive recovery is a documented subsystem with its own page in `docs/adaptive-recovery.md`, and as of #565 it has exactly one runnable example. Capability filtering is how the catalog is meant to carry a reader from a subsystem to a working example, and for this subsystem that path did not exist.

## Scope and impact

Affected areas:

- example catalog metadata and its public schema
- the runtime catalog validator that shares the same vocabulary

Public API changes: None. `catalog.schema.json` gains one enum value, which is a backward compatible addition for anything validating against it.

Breaking changes or migration requirements: None.

Dependency changes: None.

Security and privacy impact: None.

Intentional non-goals:

- no changes to any example source
- no changes to adaptive recovery behavior
- no other catalog entries retagged, because `commission-reconciliation-recovery` is currently the only example using repairable recovery

## Validation

Passed:

- `npm run test:example-catalog`
  - 9 tests passed; 64 catalog entries validated
- `npm run lint -w @open-multi-agent/core`
- `git diff --check`

The vocabulary is defined in exactly three places, and all three are updated in this change: `scripts/example-catalog-lib.mjs`, `packages/core/examples/catalog.schema.json`, and the entry in `packages/core/examples/catalog.json`. The catalog test asserts that the public schema and the runtime validator stay in sync, so a partial update would fail rather than drift silently.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
