### PR TITLE
docs: attribute the website links in the READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@
 <br />
 
 <p align="center">
-  <a href="https://open-multi-agent.com">Website</a> ·
-  <a href="https://open-multi-agent.com/getting-started/introduction/">Docs</a> ·
+  <a href="https://open-multi-agent.com/?utm_source=github&utm_medium=readme">Website</a> ·
+  <a href="https://open-multi-agent.com/getting-started/introduction/?utm_source=github&utm_medium=readme">Docs</a> ·
   <a href="./packages/core/examples/">Examples</a> ·
   <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a>
 </p>
@@ -167,7 +167,7 @@ OMA is designed for TypeScript teams that want the task graph to emerge from the
 
 Choose a graph-first framework when the workflow must be authored node by node. Use an LLM toolkit alone when one agent call is enough. OMA sits at the orchestration layer when several agents, dependencies, approvals, or recovery steps must work together.
 
-For a named head-to-head against LangGraph, Mastra, CrewAI, the Vercel AI SDK, and others, see the [comparison page](https://open-multi-agent.com/compare/).
+For a named head-to-head against LangGraph, Mastra, CrewAI, the Vercel AI SDK, and others, see the [comparison page](https://open-multi-agent.com/compare/?utm_source=github&utm_medium=readme).
 
 ## Packages
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -31,8 +31,8 @@
 <br />
 
 <p align="center">
-  <a href="https://open-multi-agent.com/zh/">官网</a> ·
-  <a href="https://open-multi-agent.com/zh/getting-started/introduction/">文档</a> ·
+  <a href="https://open-multi-agent.com/zh/?utm_source=github&utm_medium=readme">官网</a> ·
+  <a href="https://open-multi-agent.com/zh/getting-started/introduction/?utm_source=github&utm_medium=readme">文档</a> ·
   <a href="./packages/core/examples/">示例</a> ·
   <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a>
 </p>
@@ -166,7 +166,7 @@ OMA 面向希望任务图随目标动态生成的 TypeScript 团队。
 
 如果工作流必须逐节点手工设计，图优先框架更合适；如果只需要单个 Agent 调用，一个 LLM 工具库就够了。当多个 Agent、任务依赖、审批或恢复机制需要协同时，OMA 负责这一编排层。
 
-与 LangGraph、Mastra、CrewAI、Vercel AI SDK 等的逐项对比见[对比页](https://open-multi-agent.com/zh/compare/)。
+与 LangGraph、Mastra、CrewAI、Vercel AI SDK 等的逐项对比见[对比页](https://open-multi-agent.com/zh/compare/?utm_source=github&utm_medium=readme)。
 
 ## 包
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -31,8 +31,8 @@
 <br />
 
 <p align="center">
-  <a href="https://open-multi-agent.com">Website</a> ·
-  <a href="https://open-multi-agent.com/getting-started/introduction/">Docs</a> ·
+  <a href="https://open-multi-agent.com/?utm_source=npm&utm_medium=package_readme">Website</a> ·
+  <a href="https://open-multi-agent.com/getting-started/introduction/?utm_source=npm&utm_medium=package_readme">Docs</a> ·
   <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a> ·
   <a href="https://github.com/open-multi-agent/open-multi-agent/discussions">Discussions</a>
 </p>

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -31,8 +31,8 @@
 <br />
 
 <p align="center">
-  <a href="https://open-multi-agent.com/zh/">官网</a> ·
-  <a href="https://open-multi-agent.com/zh/getting-started/introduction/">文档</a> ·
+  <a href="https://open-multi-agent.com/zh/?utm_source=github&utm_medium=package_readme">官网</a> ·
+  <a href="https://open-multi-agent.com/zh/getting-started/introduction/?utm_source=github&utm_medium=package_readme">文档</a> ·
   <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a> ·
   <a href="https://github.com/open-multi-agent/open-multi-agent/discussions">讨论区</a>
 </p>


### PR DESCRIPTION
## Summary

Adds UTM attribution to all ten `open-multi-agent.com` links in the READMEs. No link target changes, no copy changes, no new redirect rules; the only structural change is a trailing slash on the bare host form.

| File | `utm_source` | `utm_medium` |
|---|---|---|
| `README.md` | `github` | `readme` |
| `README_zh.md` | `github` | `readme` |
| `packages/core/README.md` | `npm` | `package_readme` |
| `packages/core/README_zh.md` | `github` | `package_readme` |

## Motivation

Roughly 76% of visits to the site are reported as direct. A share of that is genuine, and the rest is channels that drop the referrer on the way: messaging apps, in-app webviews, email clients, QR codes. UTM parameters are the only thing that separates the two, which is why the site's GitHub link fields (profile sidebar, repository About, organization website) already carry them. The READMEs were the remaining untagged surface.

These links carry full canonical URLs rather than the site's `/go/` short links. Those short links exist for positions where the URL itself is rendered on screen; every link here is anchor text, so the URL is never shown, and a canonical URL with parameters keeps working without depending on a redirect rule surviving.

`packages/core/README.md` is the only file in the repository rendered on two platforms: it ships in the npm tarball and is also browsable on GitHub. One file carries one source, and it is sourced to `npm` because the package page is its primary audience while the folder view is reached from inside the repo. `packages/core/README_zh.md` is not in the tarball, so it stays on `github`.

Nothing is tagged more finely than that. Language needs no `utm_campaign` because the `/zh/` path prefix already separates it, and the three navigation destinations are three different paths, so link position needs no medium of its own.

## Scope and impact

Documentation only: four README files, ten lines. No workspace source, tests, examples, CI, or release surface is touched. No public API, behavior, compatibility, or migration impact. No security or privacy impact: UTM parameters carry no visitor data, and the site's analytics is first-party and cookieless.

Intentional non-goals:

- `docs/*.md` and the release notes stay untagged. The website vendors both, and its link rewriter only rewrites relative links, so an absolute tagged URL would come back as an on-site link carrying a campaign.
- The `homepage` fields in `package.json` stay pointed at the repository.
- Issue and PR templates and the `create-oma-app` project templates stay untagged, because their text is copied into other people's issues and repositories.
- `packages/otel/README.md` and `packages/create-oma-app/README.md` have no website link today and do not gain one here.

## Validation

- `git diff --check`: clean.
- Parsed all ten URLs: parameters are limited to `utm_source` and `utm_medium`, every path ends in a trailing slash, and all six destination paths resolve to a built page (`/`, `/zh/`, `/getting-started/introduction/`, `/zh/getting-started/introduction/`, `/compare/`, `/zh/compare/`). The site sets `trailingSlash: 'always'`, so keeping the slash avoids an edge redirect in front of every one of these links.
- Confirmed each of the ten links has a unique `(utm_source, utm_medium, path)` triple, so no two positions collapse into a single row on the dashboard.
- Confirmed with an HTML parser that the unescaped `&` inside the `<a href>` attributes is not consumed as a character reference, so `&utm_medium` survives literally.
- `npm pack --dry-run` in `packages/core`: only `README.md` and `LICENSE` ship, which is what makes `README_zh.md` a GitHub-only surface.

No test suite was run. This is a documentation-only change, and the only test in the repository that asserts README content is the `create-oma-app` scaffold test, which reads generated project templates rather than these files.

Not verified: live behavior against the deployed site. Everything above was checked against the site's build output and configuration, so a rule outside `public/_redirects` that rewrote or stripped query strings would not be visible from here.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries
- [x] A relevant issue is linked when one exists
