### PR TITLE
fix(release): detect a release by the version field, not the manifest diff

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -188,9 +188,14 @@ the full set of template traps.
    the normal PR CI remain authoritative. Never merge a release proposal merely
    because its model reviewer approved it.
 3. **Wait for `CI` on the exact merged release commit.** A successful `CI`
-   workflow run on `main` triggers `publish.yml`. The publisher verifies that
-   both core and create-oma-app versions increased relative to that commit's
-   first parent; later unrelated commits cannot accidentally publish.
+   workflow run on `main` triggers `publish.yml`, which reads the `version`
+   field of the core and create-oma-app manifests at that commit and at its
+   first parent and stops before the publish job unless both moved. The
+   publisher then re-derives the same fact and refuses a commit whose versions
+   did not increment, so later unrelated commits cannot accidentally publish.
+   Reading the version rather than asking whether those manifests changed at
+   all is what keeps an ordinary dependency or metadata edit from starting a
+   job that mints a write-scoped token and then fails closed.
 4. **Publish to npm in order: `core`, then `otel` when its declared version is
    not already live, then `create-oma-app`.** The publisher checks the public
    registry before every action and waits for each new version to resolve

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,16 +60,40 @@ jobs:
         run: |
           set -euo pipefail
           echo "sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
-          if git diff --quiet "$RELEASE_SHA^" "$RELEASE_SHA" -- packages/core/package.json; then
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
-            echo "core version manifest did not change; publication is a no-op"
-            exit 0
-          fi
-          if git diff --quiet "$RELEASE_SHA^" "$RELEASE_SHA" -- packages/create-oma-app/package.json; then
-            echo "is_release=false" >> "$GITHUB_OUTPUT"
-            echo "create-oma-app version manifest did not change; publication is a no-op"
-            exit 0
-          fi
+          # Read the version field rather than asking whether the manifest
+          # changed at all, so this agrees with the publisher's own guard:
+          # both versions must have incremented from the first parent. A
+          # dependency bump, a metadata fix, or an `exports` edit touches
+          # these files without being a release, and detecting on the file
+          # made every one of those start the publish job, mint a
+          # contents:write App token, and only then fail closed. Verified on
+          # 98516ce, a dependency-only commit that reached this step as a
+          # false positive.
+          manifest_exists() { git cat-file -e "$1:$2" 2>/dev/null; }
+          version_at() { git show "$1:$2" | jq -r '.version // empty'; }
+          for manifest in packages/core/package.json packages/create-oma-app/package.json; do
+            if ! manifest_exists "$RELEASE_SHA" "$manifest"; then
+              echo "is_release=false" >> "$GITHUB_OUTPUT"
+              echo "$manifest does not exist at $RELEASE_SHA; publication is a no-op"
+              exit 0
+            fi
+            version=$(version_at "$RELEASE_SHA" "$manifest")
+            if [ -z "$version" ]; then
+              echo "::error::$manifest declares no version at $RELEASE_SHA"
+              exit 1
+            fi
+            # A missing parent manifest means this one is new here, which
+            # counts as a change rather than a reason to skip publication.
+            parent=''
+            if manifest_exists "$RELEASE_SHA^" "$manifest"; then
+              parent=$(version_at "$RELEASE_SHA^" "$manifest")
+            fi
+            if [ "$version" = "$parent" ]; then
+              echo "is_release=false" >> "$GITHUB_OUTPUT"
+              echo "$manifest still declares $version; publication is a no-op"
+              exit 0
+            fi
+          done
           echo "is_release=true" >> "$GITHUB_OUTPUT"
 
   publish:


### PR DESCRIPTION
## Summary

`publish.yml` decided whether a commit on `main` was a release by asking whether `packages/core/package.json` and `packages/create-oma-app/package.json` had changed at all. Those files carry more than a version — dependency specs, `exports`, `files`, `engines`, keywords — so any edit to either one read as a release. The detection now reads the `version` field at the release commit and at its first parent and stops unless both moved, which is the same fact the publisher re-derives later.

## Motivation

98516ce (#570) was the first commit to hit this. It only pinned dependency specs; neither version moved. But both manifests changed, so `detect_release_commit` reported `is_release=true` and the `publish` job started: it entered the `npm-release` environment, minted a `contents: write` GitHub App token, checked out, installed, built, and only then stopped at the publisher's own guard.

```
release-bot: 98516ce... is not a release commit: @open-multi-agent/core did not increment from its first parent.
```

Nothing was published, tagged, or released — `assertReleaseCommit` is the second statement in `publishRelease()`, ahead of every registry and git mutation, and the registry still reads `core@1.17.0` / `otel@0.1.2` / `create-oma-app@0.8.3` with no tag pointing at that commit. The safety net worked. But the outer gate should not have opened: a dependency bump is the most ordinary maintenance there is, and it should not cost a write-scoped token and a red `Publish` run each time. Run: [33782185634](https://github.com/open-multi-agent/open-multi-agent/actions/runs/33782185634).

## Scope and impact

**Release automation only.** No workspace source, no published package, no test.

Three behaviors, each deliberate:

- **Both versions moved** → `is_release=true`, as before.
- **A manifest is absent at the release commit** → `is_release=false`. This is what the old file comparison already concluded for commits predating the monorepo layout, and treating it as an error would have been a new failure mode for no gain.
- **A manifest exists but declares no version** → the job fails. That is a broken tree rather than an ordinary commit, and failing here skips the publish job, so it fails closed.

`.github/RELEASING.md` step 3 said the *publisher* verifies both versions increased, which was true but left the impression that nothing ran before that point. It now describes both gates and why the outer one reads the version field.

**Public API:** none. **Compatibility:** none. **Non-goal:** the publisher's own `assertReleaseCommit` is unchanged. Two independent checks of the same fact is the right shape — this PR only stops the outer one from being looser than the inner one.

## Validation

The step was extracted from its YAML and executed against real commits, since no pull request can trigger `publish.yml`.

**Every `v*` tag in the repository (24 of them):**

| Tag range | Result | Reading |
|---|---|---|
| v1.16.0, v1.16.1, v1.17.0 | `true` | Every release from after `publish.yml` existed still detects. No regression on anything this workflow has actually handled. |
| v1.8.0–v1.10.0, v1.13.0–v1.15.0 | `true` | Would have detected correctly. |
| v0.2.0–v1.7.0 | `false`, "manifest does not exist" | Predates `packages/core/package.json`. Graceful, not an error. |
| v1.11.0, v1.12.1 | `false` | Their tagged commits genuinely did not move both versions — v1.11.0 left core at 1.11.0, v1.12.1 left create-oma-app at 0.5.0. Both predate this workflow, and the publisher would have refused them for that exact reason, so the gate now agrees with the publisher instead of deferring the disagreement to a failed job. |

**Headline cases, both versions of the step run side by side:**

| Commit | Old | New |
|---|---|---|
| 98516ce, dependency-only (#570) | `true` — the false positive | `false`, "packages/core/package.json still declares 1.17.0" |
| 3b21a7c, the real v1.17.0 release commit | `true` | `true` |
| 72af1c5, docs-only (#569) | `false` | `false` |
| an unresolvable SHA | `true` | `false` |

That last row is a second thing the change fixes, found while building the harness rather than looked for. `git diff --quiet` exits 1 for "changed" and 128 for "could not run", and the old step read both as "changed", so any git failure resolved to `is_release=true` — a publish gate that fails open. Reading the version field fails closed instead. It is unreachable in practice, since `actions/checkout` and the "Verify the candidate belongs to main" step both run first and would already have failed hard, but a gate should not lean on that.

**Error path:** a synthetic repository where core's manifest loses its `version` between two commits exits 1, writes `::error::packages/core/package.json declares no version at <sha>`, and writes no `is_release`, so the dependent job is skipped.

Also run: `git diff --check` (clean) and a YAML parse of `publish.yml`. No workspace code changed, so the lint, test, and build suites are not applicable to the diff; PR CI runs them regardless.

**Not run:** `publish.yml` itself, which cannot be exercised from a pull request. The next real release is the first live run of this path; if it were wrong, the failure mode is the publisher refusing to publish rather than publishing something it should not, and `workflow_dispatch` recovery with an explicit SHA is unchanged.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries
- [ ] A relevant issue is linked when one exists
