### PR TITLE
test(core): add a MemoryStore contract suite and type-check the store contracts

### DIFF
--- a/packages/core/tests/contract-suite-types.test.ts
+++ b/packages/core/tests/contract-suite-types.test.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The reusable store contract suites describe a public contract, and they do it
+ * using the public barrels so they stay honest about what an outside
+ * implementer can reach. Nothing else enforces that: `tests/` is excluded from
+ * both `tsconfig.json` and `tsconfig.lint.json`, and Vitest strips types
+ * without checking them, so a suite can drift to a non-exported type or an
+ * unsound cast and still go green.
+ *
+ * This closes that gap with the same in-test tsc idiom
+ * `observability-doc-examples.test.ts` uses for the excluded example projects.
+ */
+describe('store contract suites', () => {
+  it('typecheck against the public barrels', () => {
+    const configPath = fileURLToPath(new URL('./helpers/tsconfig.json', import.meta.url))
+    const loaded = ts.readConfigFile(configPath, ts.sys.readFile)
+    expect(loaded.error).toBeUndefined()
+    const parsed = ts.parseJsonConfigFileContent(
+      loaded.config,
+      ts.sys,
+      fileURLToPath(new URL('./helpers', import.meta.url)),
+      undefined,
+      configPath,
+    )
+    expect(parsed.fileNames.length).toBeGreaterThan(0)
+    const program = ts.createProgram(parsed.fileNames, parsed.options)
+    const diagnostics = ts.getPreEmitDiagnostics(program)
+    const formatted = ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+      getCanonicalFileName: (fileName) => fileName,
+      getCurrentDirectory: ts.sys.getCurrentDirectory,
+      getNewLine: () => ts.sys.newLine,
+    })
+    expect(formatted).toBe('')
+  })
+})

--- a/packages/core/tests/eval-file-store.test.ts
+++ b/packages/core/tests/eval-file-store.test.ts
@@ -29,7 +29,7 @@ import {
   evalRecord,
   runEvalStoreContractSuite,
   type EvalStoreContractFactoryOptions,
-} from './eval-store-contract.js'
+} from './helpers/eval-store-contract.js'
 
 const temporaryRoots: string[] = []
 

--- a/packages/core/tests/eval-in-memory-store.test.ts
+++ b/packages/core/tests/eval-in-memory-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { InMemoryEvalStore } from '../src/eval/store.js'
-import { evalRecord, runEvalStoreContractSuite } from './eval-store-contract.js'
+import { evalRecord, runEvalStoreContractSuite } from './helpers/eval-store-contract.js'
 
 runEvalStoreContractSuite(
   'InMemoryEvalStore',

--- a/packages/core/tests/helpers/eval-store-contract.ts
+++ b/packages/core/tests/helpers/eval-store-contract.ts
@@ -1,9 +1,21 @@
+/**
+ * Behavioral contract for {@link EvalStore} implementations.
+ *
+ * Imports resolve through the public `/eval` barrel rather than deep `src/`
+ * paths, so the suite type-checks against exactly the surface a third-party
+ * implementer sees.
+ *
+ * Both shipped stores run it unchanged: `InMemoryEvalStore` in
+ * `eval-in-memory-store.test.ts` and `FileEvalStore` in
+ * `eval-file-store.test.ts`.
+ */
+
 import { describe, expect, it } from 'vitest'
-import type { EvalRecord } from '../src/eval/record.js'
 import {
   EvalStoreError,
+  type EvalRecord,
   type EvalStore,
-} from '../src/eval/store.js'
+} from '../../src/eval/index.js'
 
 export interface EvalStoreContractFactoryOptions {
   readonly now?: () => number

--- a/packages/core/tests/helpers/memory-store-contract.ts
+++ b/packages/core/tests/helpers/memory-store-contract.ts
@@ -1,0 +1,316 @@
+/**
+ * Behavioral contract for {@link MemoryStore} implementations.
+ *
+ * `MemoryStore` is the seam with the most traffic from outside the repository:
+ * it backs shared memory, checkpoint/resume, and the durable approval ledger,
+ * and `docs/shared-memory.md` invites callers to implement it against Redis,
+ * Postgres, or a vendor memory service. Until now the two shipped stores were
+ * covered by separate bespoke tests, so nothing stated which behaviors an
+ * outside implementation actually has to reproduce.
+ *
+ * Imports resolve through the public root barrel, so the suite describes the
+ * contract using exactly the surface an external implementer sees.
+ *
+ * **What this suite deliberately does not require.**
+ *
+ * - *A defensive copy on read.* Both shipped stores hand back the live entry
+ *   from their map. `MemoryEntry` is `readonly` in the type system, so "callers
+ *   must not mutate what they read" is the contract; asserting either direction
+ *   at runtime would freeze an implementation detail.
+ * - *`list()` ordering.* Both shipped stores return insertion order, but
+ *   `SharedMemory` only ever uses `list()` as a set (filter, group, delete-all).
+ *   Requiring a stable order would rule out backends that cannot cheaply give
+ *   one, for a guarantee no caller relies on.
+ * - *Expiry enforcement.* Stores persist `expiresAtTurn` and nothing more;
+ *   filtering belongs to `SharedMemory`, which owns the turn counter. A store
+ *   that hides expired entries fails this suite on purpose.
+ */
+
+import { describe, expect, it } from 'vitest'
+import type { MemoryStore } from '../../src/index.js'
+
+export interface MemoryStoreContractOptions {
+  /**
+   * Whether a value survives a write/read round trip byte for byte. Set to
+   * `false` for a store that rewrites values on the way in (`RedactingStore`)
+   * or cannot read its own writes back verbatim. Round-trip cases are then
+   * replaced by the weaker read-your-writes consistency check; every other
+   * required invariant still runs.
+   */
+  readonly preservesValues?: boolean
+  /**
+   * Opens a second handle onto the same backing state the factory just built.
+   * Supplied only by stores that claim durability, and enables the
+   * cross-instance group. A store without it is not judged on durability
+   * either way.
+   */
+  readonly reopen?: () => Promise<MemoryStore>
+}
+
+export type MemoryStoreContractFactory = () => MemoryStore | Promise<MemoryStore>
+
+/** Present only when the implementation opted into the optional method. */
+function optionalCas(store: MemoryStore) {
+  return typeof store.compareAndSet === 'function' ? store.compareAndSet.bind(store) : null
+}
+
+function optionalExpiry(store: MemoryStore) {
+  return typeof store.setWithExpiry === 'function' ? store.setWithExpiry.bind(store) : null
+}
+
+async function valuesByKey(store: MemoryStore): Promise<Map<string, string>> {
+  return new Map((await store.list()).map((entry) => [entry.key, entry.value]))
+}
+
+/**
+ * Reusable behavioral suite. Every shipped store runs it unchanged from
+ * `memory-store-contract.test.ts`.
+ */
+export function runMemoryStoreContractSuite(
+  name: string,
+  createStore: MemoryStoreContractFactory,
+  options: MemoryStoreContractOptions = {},
+): void {
+  const preservesValues = options.preservesValues ?? true
+
+  describe(`${name} MemoryStore contract`, () => {
+    // -----------------------------------------------------------------------
+    // Required: read/write
+    // -----------------------------------------------------------------------
+
+    it('returns null for an absent key and a populated entry after a write', async () => {
+      const store = await createStore()
+      await expect(store.get('missing')).resolves.toBeNull()
+
+      await store.set('present', 'value-1')
+      const entry = await store.get('present')
+      expect(entry).not.toBeNull()
+      expect(entry?.key).toBe('present')
+      expect(entry?.createdAt).toBeInstanceOf(Date)
+      expect(Number.isNaN(entry!.createdAt.getTime())).toBe(false)
+
+      // Read-your-writes: whatever the store chose to persist, `get` and
+      // `list` must agree on it. A lossy store still owes this.
+      expect((await valuesByKey(store)).get('present')).toBe(entry?.value)
+      if (preservesValues) {
+        expect(entry?.value).toBe('value-1')
+      }
+    })
+
+    it('replaces the value on re-set and preserves the original createdAt', async () => {
+      const store = await createStore()
+      await store.set('key', 'first')
+      const created = (await store.get('key'))!.createdAt
+
+      await new Promise((resolve) => setTimeout(resolve, 2))
+      await store.set('key', 'second')
+
+      const updated = await store.get('key')
+      expect(updated!.createdAt.getTime()).toBe(created.getTime())
+      expect((await store.list()).filter((entry) => entry.key === 'key')).toHaveLength(1)
+      if (preservesValues) {
+        expect(updated?.value).toBe('second')
+      }
+    })
+
+    // -----------------------------------------------------------------------
+    // Required: metadata
+    // -----------------------------------------------------------------------
+
+    it('round-trips metadata, copies it on write, and clears it when omitted', async () => {
+      const store = await createStore()
+      const metadata: Record<string, unknown> = { agent: 'researcher', turn: 3, nested: { a: 1 } }
+      await store.set('meta', 'value', metadata)
+      expect((await store.get('meta'))?.metadata).toEqual({
+        agent: 'researcher',
+        turn: 3,
+        nested: { a: 1 },
+      })
+
+      // The store must not retain the caller's object.
+      metadata['agent'] = 'mutated'
+      expect((await store.get('meta'))?.metadata).toMatchObject({ agent: 'researcher' })
+
+      // Re-setting without metadata clears it rather than merging.
+      await store.set('meta', 'value-2')
+      expect((await store.get('meta'))?.metadata).toBeUndefined()
+
+      await store.set('no-meta', 'value')
+      expect((await store.get('no-meta'))?.metadata).toBeUndefined()
+    })
+
+    // -----------------------------------------------------------------------
+    // Required: list
+    // -----------------------------------------------------------------------
+
+    it('lists every written key exactly once and nothing on an empty store', async () => {
+      const store = await createStore()
+      expect(await store.list()).toEqual([])
+
+      await store.set('a', '1')
+      await store.set('b', '2')
+      await store.set('a', '1-updated')
+
+      const keys = (await store.list()).map((entry) => entry.key)
+      expect(keys).toHaveLength(2)
+      expect(new Set(keys)).toEqual(new Set(['a', 'b']))
+    })
+
+    // -----------------------------------------------------------------------
+    // Required: delete / clear
+    // -----------------------------------------------------------------------
+
+    it('makes delete idempotent, silent on an absent key, and invisible to reads', async () => {
+      const store = await createStore()
+      await store.set('doomed', 'value')
+      await store.set('kept', 'value')
+
+      await expect(store.delete('doomed')).resolves.toBeUndefined()
+      await expect(store.get('doomed')).resolves.toBeNull()
+      expect((await store.list()).map((entry) => entry.key)).toEqual(['kept'])
+
+      // Deleting twice, and deleting something that never existed, are no-ops.
+      await expect(store.delete('doomed')).resolves.toBeUndefined()
+      await expect(store.delete('never-written')).resolves.toBeUndefined()
+      expect((await store.list()).map((entry) => entry.key)).toEqual(['kept'])
+    })
+
+    it('empties the store on clear, tolerates clearing twice, and re-dates a rewritten key', async () => {
+      const store = await createStore()
+      await store.set('key', 'value')
+      const before = (await store.get('key'))!.createdAt
+
+      await store.clear()
+      expect(await store.list()).toEqual([])
+      await expect(store.get('key')).resolves.toBeNull()
+      await expect(store.clear()).resolves.toBeUndefined()
+
+      // `clear` removes the entry, so a later write starts a new lifetime
+      // rather than resurrecting the old createdAt.
+      await new Promise((resolve) => setTimeout(resolve, 2))
+      await store.set('key', 'value')
+      expect((await store.get('key'))!.createdAt.getTime()).toBeGreaterThan(before.getTime())
+    })
+
+    // -----------------------------------------------------------------------
+    // Optional: compareAndSet
+    // -----------------------------------------------------------------------
+
+    describe('compareAndSet (optional)', () => {
+      it('gates on the expected value and preserves createdAt on success', async (ctx) => {
+        const store = await createStore()
+        const cas = optionalCas(store)
+        // A store may legitimately omit the method; durable approvals then fail
+        // closed. Skip rather than return, so an omission reads as "skipped" in
+        // the report instead of being indistinguishable from a real pass.
+        if (cas === null) return ctx.skip()
+
+        // `null` means "must not exist".
+        await expect(cas('cas', null, 'first')).resolves.toBe(true)
+        const created = (await store.get('cas'))!.createdAt
+        const stored = (await store.get('cas'))!.value
+
+        // The key now exists, so the create-only claim must fail and change nothing.
+        await expect(cas('cas', null, 'clobbered')).resolves.toBe(false)
+        expect((await store.get('cas'))?.value).toBe(stored)
+
+        // A stale expectation must fail and change nothing.
+        await expect(cas('cas', 'not-the-current-value', 'clobbered')).resolves.toBe(false)
+        expect((await store.get('cas'))?.value).toBe(stored)
+
+        // A matching expectation succeeds and keeps the original createdAt.
+        await expect(cas('cas', stored, 'second')).resolves.toBe(true)
+        expect((await store.get('cas'))!.createdAt.getTime()).toBe(created.getTime())
+        if (preservesValues) {
+          expect((await store.get('cas'))?.value).toBe('second')
+        }
+      })
+
+      it('lets exactly one of two racing claims on the same expected value win', async (ctx) => {
+        const store = await createStore()
+        const cas = optionalCas(store)
+        if (cas === null) return ctx.skip()
+
+        await store.set('race', 'start')
+        const expected = (await store.get('race'))!.value
+        const results = await Promise.all([
+          cas('race', expected, 'winner-a'),
+          cas('race', expected, 'winner-b'),
+        ])
+
+        // This is the whole point of the method: two reviewers cannot both
+        // believe they recorded the decision.
+        expect(results.filter(Boolean)).toHaveLength(1)
+      })
+    })
+
+    // -----------------------------------------------------------------------
+    // Optional: setWithExpiry
+    // -----------------------------------------------------------------------
+
+    describe('setWithExpiry (optional)', () => {
+      it('persists expiresAtTurn, never filters on it, and lets a plain set clear it', async (ctx) => {
+        const store = await createStore()
+        const setWithExpiry = optionalExpiry(store)
+        if (setWithExpiry === null) return ctx.skip()
+
+        await setWithExpiry('ttl', 'value', 7)
+        expect((await store.get('ttl'))?.expiresAtTurn).toBe(7)
+
+        // Turn 0 is expired for every turn counter, and the store must still
+        // return it: expiry filtering belongs to SharedMemory, not here.
+        await setWithExpiry('already-expired', 'value', 0)
+        expect(await store.get('already-expired')).not.toBeNull()
+        expect((await store.list()).map((entry) => entry.key)).toContain('already-expired')
+
+        // A plain `set` writes a fresh entry with no expiry rather than
+        // inheriting the previous one.
+        await store.set('ttl', 'value-2')
+        expect((await store.get('ttl'))?.expiresAtTurn).toBeUndefined()
+      })
+
+      it('preserves createdAt across an expiring update', async (ctx) => {
+        const store = await createStore()
+        const setWithExpiry = optionalExpiry(store)
+        if (setWithExpiry === null) return ctx.skip()
+
+        await store.set('key', 'value')
+        const created = (await store.get('key'))!.createdAt
+        await new Promise((resolve) => setTimeout(resolve, 2))
+
+        await setWithExpiry('key', 'value-2', 5)
+        expect((await store.get('key'))!.createdAt.getTime()).toBe(created.getTime())
+      })
+    })
+
+    // -----------------------------------------------------------------------
+    // Optional: durability across instances
+    // -----------------------------------------------------------------------
+
+    describe('durability (optional)', () => {
+      it('replays writes and deletes to a second handle on the same backing state', async (ctx) => {
+        const reopen = options.reopen
+        if (reopen === undefined) return ctx.skip()
+        const store = await createStore()
+
+        await store.set('kept', 'value', { agent: 'writer' })
+        await store.set('removed', 'value')
+        await store.delete('removed')
+
+        const reopened = await reopen()
+        const entry = await reopened.get('kept')
+        expect(entry).not.toBeNull()
+        expect(entry?.metadata).toEqual({ agent: 'writer' })
+        expect(entry?.createdAt).toBeInstanceOf(Date)
+        await expect(reopened.get('removed')).resolves.toBeNull()
+        expect((await reopened.list()).map((item) => item.key)).toEqual(['kept'])
+
+        const expiry = optionalExpiry(store)
+        if (expiry !== null) {
+          await expiry('with-ttl', 'value', 9)
+          expect((await (await reopen()).get('with-ttl'))?.expiresAtTurn).toBe(9)
+        }
+      })
+    })
+  })
+}

--- a/packages/core/tests/helpers/trace-store-contract.ts
+++ b/packages/core/tests/helpers/trace-store-contract.ts
@@ -1,7 +1,23 @@
+/**
+ * Behavioral contract for {@link TraceStore} implementations.
+ *
+ * Imports resolve through the public barrels rather than deep `src/` paths, so
+ * the suite type-checks against exactly the surface a third-party implementer
+ * sees. Only the observability barrel is a runtime import; the root-barrel
+ * types are erased at compile time and cost the consumer nothing.
+ */
+
 import { describe, expect, it } from 'vitest'
-import type { RunStatusCode, TraceLink } from '../../src/types.js'
-import type { SpanEndRecord, SpanEventRecord, SpanStartRecord, TraceRecord } from '../../src/observability/records.js'
-import { TraceStoreError, type TraceStore, type TraceStoreDiagnostic } from '../../src/observability/store.js'
+import type { RunStatusCode, TraceLink } from '../../src/index.js'
+import {
+  TraceStoreError,
+  type SpanEndRecord,
+  type SpanEventRecord,
+  type SpanStartRecord,
+  type TraceRecord,
+  type TraceStore,
+  type TraceStoreDiagnostic,
+} from '../../src/observability/index.js'
 
 export interface TraceStoreContractFactoryOptions {
   readonly now?: () => number
@@ -66,7 +82,11 @@ function event(options: AttemptOptions): SpanEventRecord {
   }
 }
 
-/** Reusable behavioral suite. OBS-4B should invoke this unchanged for FileTraceStore. */
+/**
+ * Reusable behavioral suite. Both shipped stores run it unchanged:
+ * `InMemoryTraceStore` in `trace-store-contract.test.ts` and `FileTraceStore`
+ * in `file-trace-store.test.ts`.
+ */
 export function runTraceStoreContractSuite(name: string, createStore: TraceStoreContractFactory): void {
   describe(`${name} TraceStore contract`, () => {
     it('makes a valid batch atomically visible and rejects an invalid batch atomically', async () => {
@@ -85,7 +105,9 @@ export function runTraceStoreContractSuite(name: string, createStore: TraceStore
       const store = createStore()
       const records = attemptRecords({ runId: 'dedupe', attributes: { custom: 'first' } })
       await store.append(records)
-      records[0]!.attributes = { custom: 'mutated' } as never
+      // `TraceRecord.attributes` is readonly by type; mutate through a writable
+      // view to prove the store copied rather than retained the caller's object.
+      ;(records[0] as { attributes: Record<string, unknown> }).attributes = { custom: 'mutated' }
       await expect(store.append(records)).resolves.toMatchObject({ written: 0, deduplicated: 2 })
       const first = await store.getRun('dedupe', { includeRecords: true })
       expect(first?.records?.[0]?.attributes).toMatchObject({ custom: 'first' })
@@ -258,7 +280,9 @@ export function runTraceStoreContractSuite(name: string, createStore: TraceStore
       const record = {
         ...attemptRecords({ runId: 'minor-field', endOnly: true })[0]!,
         futureMinorField: { preserved: true },
-      } as TraceRecord
+        // A forward-compatible record carries fields this version has no type
+        // for, so the widening cast is the point of the case, not an oversight.
+      } as unknown as TraceRecord
       await store.append([record])
       expect((await store.getRun('minor-field', { includeRecords: true }))?.records?.[0])
         .toMatchObject({ futureMinorField: { preserved: true } })

--- a/packages/core/tests/helpers/tsconfig.json
+++ b/packages/core/tests/helpers/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "//": "Type-checks the reusable store contract suites, which the repository's other tsconfigs exclude along with the rest of tests/. Enforced by tests/contract-suite-types.test.ts, following the same in-test tsc idiom as examples/integrations/observability-v2. Only the contract suites are listed: they describe a public contract using the public barrels, so a type error here is a real defect rather than test-file noise.",
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "../.."
+  },
+  "include": [
+    "./eval-store-contract.ts",
+    "./memory-store-contract.ts",
+    "./trace-store-contract.ts"
+  ],
+  "exclude": []
+}

--- a/packages/core/tests/memory-store-contract.test.ts
+++ b/packages/core/tests/memory-store-contract.test.ts
@@ -1,0 +1,160 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { FileStore } from '../src/memory/file-store.js'
+import { RedactingStore } from '../src/memory/redacting-store.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import type { MemoryEntry, MemoryStore } from '../src/types.js'
+import { runMemoryStoreContractSuite } from './helpers/memory-store-contract.js'
+
+let dir: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'oma-memory-contract-'))
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+const filePath = () => join(dir, 'store.json')
+const redactedPath = () => join(dir, 'redacted.json')
+
+runMemoryStoreContractSuite('InMemoryStore', () => new InMemoryStore())
+
+runMemoryStoreContractSuite('FileStore', () => new FileStore(filePath()), {
+  reopen: async () => new FileStore(filePath()),
+})
+
+// The decorator is in the suite for two reasons: it is the only shipped store
+// that omits an optional method, and the only one that rewrites values on the
+// way in. Both are shapes a third-party store can legitimately have, so the
+// contract has to stay satisfiable under them.
+runMemoryStoreContractSuite(
+  'RedactingStore(FileStore)',
+  () => new RedactingStore(new FileStore(redactedPath())),
+  {
+    preservesValues: false,
+    reopen: async () => new RedactingStore(new FileStore(redactedPath())),
+  },
+)
+
+/**
+ * The store a competent implementer writes on a first pass against the type
+ * signature alone. It satisfies the compiler and every obvious case; each
+ * deviation below is one a reviewer caught in a real submission (#335) or one
+ * the interface documents but the type cannot express.
+ */
+class NaiveStore implements MemoryStore {
+  private readonly data = new Map<string, MemoryEntry>()
+  private turn = 0
+
+  async get(key: string): Promise<MemoryEntry | null> {
+    const entry = this.data.get(key)
+    // Bug: hides expired entries. Expiry filtering belongs to SharedMemory,
+    // which owns the turn counter; a store that filters double-counts it.
+    if (entry?.expiresAtTurn !== undefined && this.turn >= entry.expiresAtTurn) return null
+    return entry ?? null
+  }
+
+  async set(key: string, value: string, metadata?: Record<string, unknown>): Promise<void> {
+    // Bug 1: resets createdAt on update, so callers cannot tell when a value
+    // was first written. Bug 2: retains the caller's metadata object.
+    this.data.set(key, { key, value, metadata, createdAt: new Date() })
+  }
+
+  async compareAndSet(
+    key: string,
+    expectedValue: string | null,
+    value: string,
+  ): Promise<boolean> {
+    // Bug: yields to the event loop between the read and the write, so two
+    // callers can both observe the same expected value and both claim success.
+    const existing = this.data.get(key)
+    await Promise.resolve()
+    if ((existing?.value ?? null) !== expectedValue) return false
+    this.data.set(key, { key, value, createdAt: existing?.createdAt ?? new Date() })
+    return true
+  }
+
+  async setWithExpiry(key: string, value: string, expiresAtTurn: number): Promise<void> {
+    this.data.set(key, { key, value, createdAt: new Date(), expiresAtTurn })
+  }
+
+  async list(): Promise<MemoryEntry[]> {
+    return Array.from(this.data.values())
+  }
+
+  async delete(key: string): Promise<void> {
+    this.data.delete(key)
+  }
+
+  async clear(): Promise<void> {
+    this.data.clear()
+  }
+}
+
+describe('MemoryStore contract discrimination', () => {
+  // A conformance suite that only ever passes proves nothing. Each case below
+  // asserts the exact opposite of a suite case, on a store built to get that
+  // one thing wrong, so the invariant is shown to be discriminating rather
+  // than trivially true. The pairing is by construction, not enforced: these
+  // do not re-run the suite, they pin the behavior the suite would reject.
+  it('rejects a store that resets createdAt on update', async () => {
+    const store = new NaiveStore()
+    await store.set('key', 'first')
+    const created = (await store.get('key'))!.createdAt
+    await new Promise((resolve) => setTimeout(resolve, 2))
+    await store.set('key', 'second')
+    expect((await store.get('key'))!.createdAt.getTime()).not.toBe(created.getTime())
+  })
+
+  it('rejects a store that retains the caller metadata object', async () => {
+    const store = new NaiveStore()
+    const metadata: Record<string, unknown> = { agent: 'researcher' }
+    await store.set('meta', 'value', metadata)
+    metadata['agent'] = 'mutated'
+    expect((await store.get('meta'))?.metadata).toMatchObject({ agent: 'mutated' })
+  })
+
+  it('rejects a store that filters expired entries itself', async () => {
+    const store = new NaiveStore()
+    await store.setWithExpiry('already-expired', 'value', 0)
+    expect(await store.get('already-expired')).toBeNull()
+  })
+
+  it('rejects a store whose compareAndSet is not atomic across an await', async () => {
+    const store = new NaiveStore()
+    await store.set('race', 'start')
+    const results = await Promise.all([
+      store.compareAndSet('race', 'start', 'winner-a'),
+      store.compareAndSet('race', 'start', 'winner-b'),
+    ])
+    expect(results.filter(Boolean)).toHaveLength(2)
+  })
+})
+
+describe('MemoryStore contract coverage', () => {
+  it('exercises a store that omits compareAndSet and one that provides it', () => {
+    // Guards the capability probe itself: if every store under test answered
+    // the same way, the optional groups would be vacuous and nobody would
+    // notice.
+    // Read through the interface, which is how SharedMemory probes and the
+    // only view in which the decorator's omission is even expressible: the
+    // concrete `RedactingStore` type declares no `compareAndSet` at all.
+    const provided: MemoryStore = new FileStore(filePath())
+    const omitted: MemoryStore = new RedactingStore(new FileStore(redactedPath()))
+    expect(typeof provided.compareAndSet).toBe('function')
+    expect(omitted.compareAndSet).toBeUndefined()
+  })
+
+  it('exercises a store that actually loses values, justifying preservesValues', async () => {
+    // `preservesValues: false` above must reflect real behavior rather than a
+    // precaution, or the flag would silently weaken the suite for free.
+    const store = new RedactingStore(new FileStore(redactedPath()))
+    await store.set('secret', 'token sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789')
+    const stored = (await store.get('secret'))!.value
+    expect(stored).not.toContain('sk-ant-api03-abcdefghijklmnopqrstuvwxyz0123456789')
+  })
+})


### PR DESCRIPTION
## Why

`packages/core/README.md` sells shared memory as pluggable, and `docs/shared-memory.md` tells callers to implement `MemoryStore` against Redis, Postgres, or a vendor memory service. Several people have. `MemoryStore` was nevertheless the only one of these seams with no shared test: `InMemoryStore` and `FileStore` were each covered by their own bespoke suite, so nothing stated which behaviors an outside implementation actually has to reproduce.

The cost of that shows up in review rather than in CI. A submitted store was turned away for returning `string | undefined` from `get()` and taking a `prefix` on `list()`, and the only verification available to its author at the time was to run it against a live paid service. Two shipped integration examples diverge in ways no type check can see: one omits `compareAndSet`, which the interface documents as making suspendable approvals fail closed, and one serves reads from a process-local map so writes do not survive a restart. Both are defensible designs. Neither is discoverable.

This adds the missing suite and puts the existing ones under a type checker. It changes no runtime code and no public surface.

## What changed

**A `MemoryStore` contract suite**, run unchanged against `InMemoryStore`, `FileStore`, and `RedactingStore(FileStore)`.

The decorator earns its place by being awkward: it omits `compareAndSet` outright and rewrites values on the way in. Keeping it green proves the contract stays satisfiable by a store that is legitimately not shaped like the others. Optional methods are probed exactly the way `SharedMemory` probes them, and skip visibly rather than passing vacuously.

Three things the suite refuses to require, each recorded with its reason:

| Not required | Why |
|---|---|
| A defensive copy on read | Both shipped stores hand back the live entry. `MemoryEntry` is `readonly` in the type system, so "callers must not mutate what they read" is the contract; asserting either direction would freeze an implementation detail. |
| A stable `list()` order | `SharedMemory` only uses `list()` as a set. Requiring an order would rule out backends that cannot cheaply give one, for a guarantee no caller relies on. |
| Expiry filtering | Stores persist `expiresAtTurn` and nothing else; filtering belongs to `SharedMemory`, which owns the turn counter. A store that hides expired entries fails on purpose. |

**A discrimination group.** A suite that can only ever pass proves nothing, so a deliberately naive store pins what each required invariant rejects: resetting `createdAt` on update, retaining the caller's metadata object, filtering expired entries, and a `compareAndSet` that yields between its read and its write.

**The contract suites now type-check.** `tests/` is excluded from both `tsconfig.json` and `tsconfig.lint.json`, and Vitest strips types without checking them, so no test file in this repository has ever been type-checked. A directory `tsconfig.json` plus the in-test `tsc` idiom already used for the excluded example projects closes that for the three contract suites specifically, since those describe a public contract and a type error in them is a real defect rather than test-file noise.

Adding the suites to `tsconfig.lint.json` was tried first and does not work: `exclude` filters explicitly included files back out, and `tsc --listFiles` confirms zero files compiled. The check here was verified to fail on an injected error rather than silently matching nothing.

**The suites import through the public barrels** instead of deep `src/` paths, so they describe the contract using the surface an external implementer can actually reach. That change immediately surfaced two type errors the missing check had hidden: a write to the readonly `TraceRecord.attributes`, and a `TraceRecord` cast with insufficient overlap. Both are deliberate moves by the cases that make them, and now say so in the type system.

The `EvalStore` suite also moves beside its sibling in `tests/helpers/`, and a stale comment asking for work `file-trace-store.test.ts` already does is dropped.

## Scope

Deliberately internal. This publishes nothing and promises nothing: there is no new export, no new subpath, and no change to `packages/core/package.json`. Whether to ship a conformance suite that third parties can run against their own stores is a separate decision, since it turns these interfaces into a compatibility commitment. The suites are shaped so that step stays cheap if it is ever taken.

## Verification

- `npm run lint -w @open-multi-agent/core`
- `npm run test -w @open-multi-agent/core`: 140 files, 2137 passed, 3 skipped

The three skips are the intended capability skips: `RedactingStore` omits `compareAndSet`, and `InMemoryStore` claims no durability.
