### PR TITLE
docs(examples): make the example index runnable from a fresh checkout

### DIFF
--- a/packages/core/examples/README.md
+++ b/packages/core/examples/README.md
@@ -2,13 +2,35 @@
 
 Runnable scripts demonstrating `open-multi-agent`. Organized by category — pick one that matches what you're trying to do.
 
-All scripts run with `npx tsx packages/core/examples/<category>/<name>.ts`. Scripts that call a model require the corresponding API key in your environment. The full applications (see the apps section below) are the exception: they have their own `package.json` and start scripts.
+## Run an example
 
-[`catalog.json`](catalog.json) is the machine-readable inventory and website
-classification contract. The physical directories below remain the maintenance
-taxonomy; a catalog `goal` controls discovery by user intent without requiring a
-file move. `npm run test:example-catalog` validates the metadata and fails when a
-standalone example or top-level example directory is not registered.
+Examples import the framework source directly (`../../src/index.js`), so they run from a repository checkout, not from an installed package:
+
+```bash
+git clone https://github.com/open-multi-agent/open-multi-agent.git
+cd open-multi-agent
+npm install
+export ANTHROPIC_API_KEY=...   # or the key the example's header asks for
+npx tsx packages/core/examples/basics/single-agent.ts
+```
+
+Every script starts with a docblock that lists its `Run:` command and prerequisites. Most scripts default to Claude and read `ANTHROPIC_API_KEY`; the `basics/` scripts also accept `OMA_PROVIDER` + `OMA_MODEL` to switch to any built-in provider (see [docs/providers.md](../../../docs/providers.md)). Scripts that use file tools write under `.agent-workspace/` in the current directory. Two exceptions to the `npx tsx` flow: [`integrations/observability-v2/`](integrations/observability-v2/) needs `npm run build` first, and the [full applications](#apps--full-applications) have their own `package.json` and start scripts.
+
+Copying an example into your own project? Replace the `../../src/index.js` import with the published package name `@open-multi-agent/core`, or start from [`create-oma-app`](../../create-oma-app/).
+
+### No API key needed
+
+These run offline and deterministically, so they are the fastest way to see the framework move.
+
+| Example | What it shows |
+|---------|---------------|
+| [`patterns/durable-approval`](patterns/durable-approval.ts) | Suspend a task, record a reviewer decision, restore it in a fresh orchestrator. |
+| [`patterns/event-driven-dag`](patterns/event-driven-dag.ts) | A downstream task starts the moment its dependency completes. |
+| [`patterns/eval-offline-regression`](patterns/eval-offline-regression.ts) | EvalSet regression across two configurations with rule + judge scorers and a gate. |
+| [`patterns/eval-online-sampling`](patterns/eval-online-sampling.ts) | Online sampling into a local `FileEvalStore` with explicit flush and shutdown. |
+| [`cookbook/commission-reconciliation-recovery`](cookbook/commission-reconciliation-recovery.ts) | Repairable reconciliation that fails closed to manual review. |
+| [`integrations/observability-v2/`](integrations/observability-v2/) | Trace batching, stores, an application-owned OTel provider, and CLI/server/serverless lifecycles. Build first. |
+| [`providers/gemma4-local`](providers/gemma4-local.ts) | 100% local via Ollama. Needs Ollama running, no key. |
 
 ---
 
@@ -24,9 +46,76 @@ Core execution modes and input shapes. Read these first.
 | [`basics/task-pipeline`](basics/task-pipeline.ts) | `runTasks()` with explicit task DAG and dependencies. |
 | [`basics/multi-model-team`](basics/multi-model-team.ts) | Different models per agent in one team. |
 
+## cookbook — use-case recipes
+
+End-to-end examples framed around a concrete problem (meeting summarization, translation QA, competitive monitoring, etc.) rather than a single orchestration primitive. Lighter bar than `production/`: no tests or pinned model versions required. Good entry point if you want to see how the patterns compose on a real task.
+
+| Example | Problem solved |
+|---------|----------------|
+| [`cookbook/adaptive-customer-support`](cookbook/adaptive-customer-support.ts) | `runTeam()` picks only the specialists a shipping or billing escalation needs, then synthesizes a grounded reply. |
+| [`cookbook/commission-reconciliation-recovery`](cookbook/commission-reconciliation-recovery.ts) | No-key repairable reconciliation: `--case recovered` repairs evidence, `--case unresolved` fails closed to manual review (exit 1 by design). |
+| [`cookbook/meeting-summarizer`](cookbook/meeting-summarizer.ts) | Fan-out a transcript into summary, structured action items, and sentiment. |
+| [`cookbook/contract-review-dag`](cookbook/contract-review-dag.ts) | 4-task DAG (extract → compliance-check + summary → notify) with step-level retry. `FORCE_FAIL=task2` exercises retry. |
+| [`cookbook/incident-postmortem-dag`](cookbook/incident-postmortem-dag.ts) | 5-task DAG: three parallel root tasks feed a root-cause hypothesis and the final postmortem. |
+| [`cookbook/competitive-monitoring`](cookbook/competitive-monitoring.ts) | Parallel source monitoring (Twitter/Reddit/News), contradiction detection, aggregated report. |
+| [`cookbook/paper-replication-triage`](cookbook/paper-replication-triage.ts) | Multi-source replication triage with artifact discovery, seeded conflicts, and a go/no-go plan. |
+| [`cookbook/rare-disease-information-triage`](cookbook/rare-disease-information-triage.ts) | Source-isolated medical information triage with seeded misinformation and safety-boundary arbitration. |
+| [`cookbook/personalized-interview-simulator`](cookbook/personalized-interview-simulator.ts) | Interactive interviewer loop with observer flags, shared memory, and a structured debrief. |
+| [`cookbook/narrative-puzzle-hint-arbitration`](cookbook/narrative-puzzle-hint-arbitration.ts) | Multi-source hint arbitration with an external safety veto outside the generation loop. |
+| [`cookbook/market-data-integrity-verify-loop`](cookbook/market-data-integrity-verify-loop.ts) | Binance L2 integrity gate: source-specific judges refute a provisional report until a verified revision passes. |
+| [`cookbook/translation-backtranslation`](cookbook/translation-backtranslation.ts) | Translate → back-translate with a different provider → flag semantic drift. |
+
+## patterns — orchestration patterns
+
+Reusable shapes for common multi-agent problems.
+
+| Example | Pattern |
+|---------|---------|
+| [`patterns/fan-out-aggregate`](patterns/fan-out-aggregate.ts) | MapReduce-style fan-out via `AgentPool.runParallel()`. |
+| [`patterns/structured-output`](patterns/structured-output.ts) | Zod-validated JSON output from an agent. |
+| [`patterns/rich-tool-results`](patterns/rich-tool-results.ts) | Keep application-owned tool data separate while returning image content to the model. |
+| [`patterns/task-retry`](patterns/task-retry.ts) | Per-task retry with exponential backoff. |
+| [`patterns/multi-perspective-code-review`](patterns/multi-perspective-code-review.ts) | Multiple reviewer agents in parallel, then synthesis. |
+| [`patterns/research-aggregation`](patterns/research-aggregation.ts) | Multi-source research collated by a synthesis agent. |
+| [`patterns/event-driven-dag`](patterns/event-driven-dag.ts) | No-key proof that a downstream task starts when its dependency completes, without waiting for unrelated work. |
+| [`patterns/cost-tiered-pipeline`](patterns/cost-tiered-pipeline.ts) | Run the same four-stage pipeline twice to compare flagship vs tiered model cost. |
+| [`patterns/agent-handoff`](patterns/agent-handoff.ts) | Synchronous sub-agent delegation via `delegate_to_agent`. |
+| [`patterns/risk-gated-bash`](patterns/risk-gated-bash.ts) | Per-call `onToolCall` gate + `classifyBashCommand`: auto-pass read-only bash, human-review ambiguous, block destructive. |
+| [`patterns/durable-approval`](patterns/durable-approval.ts) | No-key suspend → atomic reviewer decision → fresh-orchestrator restore of the exact approved task. |
+| [`patterns/plan-replay`](patterns/plan-replay.ts) | Pin a coordinator plan with `createPlanArtifact`, then replay it with `runFromPlan`, no coordinator re-run. |
+| [`patterns/consensus`](patterns/consensus.ts) | Proposer→judge refutation loop via `runConsensus()`: default judge prompt and per-judge `judgePrompt` function. |
+| [`patterns/cross-provider-reasoning`](patterns/cross-provider-reasoning.ts) | Preserve a reasoning model's thought stream across providers via `preserveReasoningAsText`. |
+| [`patterns/eval-offline-regression`](patterns/eval-offline-regression.ts) | No-key EvalSet regression across two model configurations with rule + judge scorers and a gate. |
+| [`patterns/eval-online-sampling`](patterns/eval-online-sampling.ts) | Best-effort online sampling into `FileEvalStore` with explicit flush and shutdown. |
+
+## integrations — external systems
+
+Hooking the framework up to outside-the-box tooling. Contribution rules, including the vendor integration policy, are in [`integrations/README.md`](integrations/README.md).
+
+| Example | Integrates with |
+|---------|-----------------|
+| [`integrations/trace-observability`](integrations/trace-observability.ts) | `onTrace` spans for LLM calls, tools, and tasks. |
+| [`integrations/observability-v2/`](integrations/observability-v2/) | No-key runnable v2 batching, InMemory/File TraceStore, OTel in-memory provider, CLI, SIGTERM server, and FaaS lifecycle examples. |
+| [`integrations/mcp-github`](integrations/mcp-github.ts) | An MCP server's tools exposed to an agent via `connectMCPTools()`. |
+| [`integrations/mcp-bilig-workpaper`](integrations/mcp-bilig-workpaper.ts) | Bilig WorkPaper MCP tools for formula readback, recalculation, and persisted workbook JSON. |
+| [`integrations/mcp-open-design`](integrations/mcp-open-design.ts) | Batch fan-out over an MCP server's async jobs: N Open Design runs in parallel via `runTasks()`, each polled to completion by code. |
+| [`integrations/external-agent-acp`](integrations/external-agent-acp.ts) | External coding agents (Gemini CLI, Claude Code) as team members via the `acp` backend. |
+| [`integrations/external-agent-process`](integrations/external-agent-process.ts) | Deterministic local subprocesses as team members via the `process` backend. |
+| [`integrations/with-engram/`](integrations/with-engram/) | Engram shared memory as a `MemoryStore` plus an agent toolkit (vendor integration). |
+| [`integrations/with-tencentdb-memory/`](integrations/with-tencentdb-memory/) | TencentDB-Agent-Memory long-term memory via its Hermes Gateway sidecar (vendor integration). |
+
+## apps — full applications
+
+Complete, clone-and-run applications with their own `package.json` and dependencies. These embed OMA in a real backend, so they use `npm install` plus their own start script rather than `npx tsx`.
+
+| Example | Stack | Run |
+|---------|-------|-----|
+| [`integrations/express-customer-support/`](integrations/express-customer-support/) | Express REST API: `runTasks()` behind `POST /tickets`, per-agent Zod schemas, swappable provider env vars, HTTP error mapping (400/502/504) | `npm install && npm start` |
+| [`integrations/with-vercel-ai-sdk/`](integrations/with-vercel-ai-sdk/) | Next.js: OMA `runTeam()` plus AI SDK `useChat` streaming | `npm install && npm run dev` |
+
 ## providers — model & adapter examples
 
-One example per supported provider. All follow the same three-agent (architect / developer / reviewer) shape so they're easy to compare.
+One example per supported provider. All follow the same three-agent (architect / developer / reviewer) shape so they're easy to compare. Anthropic and OpenAI are covered by the `basics/` scripts above.
 
 | Example | Provider | Env var |
 |---------|----------|---------|
@@ -51,71 +140,9 @@ One example per supported provider. All follow the same three-agent (architect /
 | [`providers/qwen`](providers/qwen.ts) | Qwen / DashScope (OpenAI-compatible) | `DASHSCOPE_API_KEY` |
 | [`providers/moonshot`](providers/moonshot.ts) | Moonshot AI / Kimi (OpenAI-compatible) | `MOONSHOT_API_KEY` |
 
-## patterns — orchestration patterns
-
-Reusable shapes for common multi-agent problems.
-
-| Example | Pattern |
-|---------|---------|
-| [`patterns/fan-out-aggregate`](patterns/fan-out-aggregate.ts) | MapReduce-style fan-out via `AgentPool.runParallel()`. |
-| [`patterns/structured-output`](patterns/structured-output.ts) | Zod-validated JSON output from an agent. |
-| [`patterns/rich-tool-results`](patterns/rich-tool-results.ts) | Keep application-owned tool data separate while returning image content to the model. |
-| [`patterns/task-retry`](patterns/task-retry.ts) | Per-task retry with exponential backoff. |
-| [`patterns/multi-perspective-code-review`](patterns/multi-perspective-code-review.ts) | Multiple reviewer agents in parallel, then synthesis. |
-| [`patterns/research-aggregation`](patterns/research-aggregation.ts) | Multi-source research collated by a synthesis agent. |
-| [`patterns/event-driven-dag`](patterns/event-driven-dag.ts) | No-key deferred-promise proof that a downstream task starts when its dependency completes without waiting for unrelated work. |
-| [`patterns/cost-tiered-pipeline`](patterns/cost-tiered-pipeline.ts) | Run the same four-stage pipeline twice to compare flagship vs tiered model cost. |
-| [`patterns/agent-handoff`](patterns/agent-handoff.ts) | Synchronous sub-agent delegation via `delegate_to_agent`. |
-| [`patterns/risk-gated-bash`](patterns/risk-gated-bash.ts) | Per-call `onToolCall` gate + `classifyBashCommand`: auto-pass read-only bash, human-review ambiguous, block destructive. |
-| [`patterns/durable-approval`](patterns/durable-approval.ts) | No-key suspend → atomic reviewer decision → fresh-orchestrator restore of the exact approved task. |
-| [`patterns/plan-replay`](patterns/plan-replay.ts) | Pin a coordinator plan with `createPlanArtifact`, then replay it with `runFromPlan`, no coordinator re-run. |
-| [`patterns/consensus`](patterns/consensus.ts) | Proposer→judge refutation loop via `runConsensus()`: default judge prompt and per-judge `judgePrompt` function. |
-| [`patterns/cross-provider-reasoning`](patterns/cross-provider-reasoning.ts) | Preserve a reasoning model's thought stream across providers via `preserveReasoningAsText`. |
-| [`patterns/eval-offline-regression`](patterns/eval-offline-regression.ts) | No-key EvalSet regression across two model configurations with rule + judge scorers and a gate. |
-| [`patterns/eval-online-sampling`](patterns/eval-online-sampling.ts) | Best-effort online sampling into `FileEvalStore` with explicit flush and shutdown. |
-
-## cookbook — use-case recipes
-
-End-to-end examples framed around a concrete problem (meeting summarization, translation QA, competitive monitoring, etc.) rather than a single orchestration primitive. Lighter bar than `production/`: no tests or pinned model versions required. Good entry point if you want to see how the patterns compose on a real task.
-
-| Example | Problem solved |
-|---------|----------------|
-| [`cookbook/adaptive-customer-support`](cookbook/adaptive-customer-support.ts) | `runTeam()` selects only the relevant specialists for a shipping or billing escalation, then synthesizes a grounded customer response. |
-| [`cookbook/commission-reconciliation-recovery`](cookbook/commission-reconciliation-recovery.ts) | No-key repairable reconciliation: `--case recovered` completes a targeted evidence repair; `--case unresolved` reaches the real revision limit and fails closed to `MANUAL_REVIEW_REQUIRED` (intentional exit 1), while both preserve truthful task history. |
-| [`cookbook/meeting-summarizer`](cookbook/meeting-summarizer.ts) | Fan-out post-processing of a transcript into summary, structured action items, and sentiment. |
-| [`cookbook/contract-review-dag`](cookbook/contract-review-dag.ts) | 4-task DAG (extract → compliance-check + summary → notify) with step-level retry. Run normally or with `FORCE_FAIL=task2` to exercise retry. |
-| [`cookbook/incident-postmortem-dag`](cookbook/incident-postmortem-dag.ts) | 5-task DAG with three parallel root tasks (log patterns + deploy correlation + blast radius) feeding root-cause hypothesis and final postmortem synthesis. |
-| [`cookbook/competitive-monitoring`](cookbook/competitive-monitoring.ts) | Parallel source monitoring (Twitter/Reddit/News), contradiction detection, and aggregated intelligence reporting. |
-| [`cookbook/paper-replication-triage`](cookbook/paper-replication-triage.ts) | Multi-source paper replication triage with artifact discovery, seeded conflicts, and a structured go/no-go plan. |
-| [`cookbook/rare-disease-information-triage`](cookbook/rare-disease-information-triage.ts) | Source-isolated rare disease information triage with mock fixtures, seeded misinformation/conflict detection, and safety-boundary arbitration. |
-| [`cookbook/personalized-interview-simulator`](cookbook/personalized-interview-simulator.ts) | Interactive interviewer loop with observer flags, shared memory, and structured debrief. |
-| [`cookbook/narrative-puzzle-hint-arbitration`](cookbook/narrative-puzzle-hint-arbitration.ts) | Multi-source hint arbitration with an external safety veto that sits outside the generation loop. |
-| [`cookbook/market-data-integrity-verify-loop`](cookbook/market-data-integrity-verify-loop.ts) | Binance L2 integrity gate where source-specific judges refute a provisional report and require a verified quarantine revision. |
-| [`cookbook/translation-backtranslation`](cookbook/translation-backtranslation.ts) | Translate → back-translate with a different provider → flag semantic drift (cross-model). |
-
-## integrations — external systems
-
-Hooking the framework up to outside-the-box tooling.
-
-| Example | Integrates with |
-|---------|-----------------|
-| [`integrations/trace-observability`](integrations/trace-observability.ts) | `onTrace` spans for LLM calls, tools, and tasks. |
-| [`integrations/observability-v2/`](integrations/observability-v2/) | No-key runnable v2 batching, InMemory/File TraceStore, OTel in-memory provider, CLI, SIGTERM server, and FaaS lifecycle examples. |
-| [`integrations/mcp-github`](integrations/mcp-github.ts) | An MCP server's tools exposed to an agent via `connectMCPTools()`. |
-| [`integrations/mcp-bilig-workpaper`](integrations/mcp-bilig-workpaper.ts) | Bilig WorkPaper MCP tools for formula readback, recalculation, and persisted workbook JSON. |
-| [`integrations/mcp-open-design`](integrations/mcp-open-design.ts) | Batch fan-out over an MCP server's async jobs: N Open Design runs generated in parallel via `runTasks()`, each polling `get_run` to completion with code-driven orchestration. |
-## apps — full applications
-
-Complete, clone-and-run applications with their own `package.json` and dependencies. These embed OMA in a real backend, so they use `npm install` plus their own start script rather than `npx tsx`.
-
-| Example | Stack | Run |
-|---------|-------|-----|
-| [`integrations/express-customer-support/`](integrations/express-customer-support/) | Express REST API: `runTasks()` behind `POST /tickets`, per-agent Zod schemas, swappable provider env vars, HTTP error mapping (400/502/504) | `npm install && npm start` |
-| [`integrations/with-vercel-ai-sdk/`](integrations/with-vercel-ai-sdk/) | Next.js: OMA `runTeam()` plus AI SDK `useChat` streaming | `npm install && npm run dev` |
-
 ## production — real-world use cases
 
-End-to-end examples wired to real workflows. Higher bar than the categories above. See [`production/README.md`](production/README.md) for the acceptance criteria and how to contribute.
+Reserved for end-to-end examples with error handling, pinned model versions, and tests. **This directory is currently empty**: the `cookbook/` recipes above are the closest thing today. The acceptance criteria and layout for a first entry are in [`production/README.md`](production/README.md). Contributions welcome.
 
 ---
 
@@ -126,7 +153,8 @@ End-to-end examples wired to real workflows. Higher bar than the categories abov
 | A new model provider | `providers/` | `<provider-name>.ts` (lowercase, hyphenated) |
 | A reusable orchestration pattern | `patterns/` | `<pattern-name>.ts` |
 | A use-case-driven example (problem-first, uses one or more patterns) | `cookbook/` | `<use-case>.ts` |
-| Integration with an outside system (MCP server, observability backend, framework, app) | `integrations/` | `<system>.ts` or `<system>/` for multi-file |
+| Integration with an outside system (MCP server, observability backend, framework) | `integrations/` | `<protocol>-<name>.ts` for single-file wiring, `with-<product>/` for multi-file vendor integrations |
+| A full application with its own `package.json` | `integrations/` | `<name>/` directory; it is listed under **apps** above |
 | A real-world end-to-end use case, production-grade | `production/` | `<use-case>/` directory with its own README |
 
 Conventions:
@@ -135,6 +163,6 @@ Conventions:
 - **File header docstring** with one-line title, `Run:` block, and prerequisites.
 - **Imports** should resolve as `from '../../src/index.js'` for scripts (one level deeper than the old flat layout); full applications with their own `package.json` import the published `@open-multi-agent/core` package name instead.
 - **Match the provider template** when adding a provider: three-agent team (architect / developer / reviewer) building a small REST API. Keeps comparisons honest.
-- **Add a row** to the table in this file for the corresponding category.
-- **Add exactly one entry** to [`catalog.json`](catalog.json), including its user goal, capability tags, format, level, and any directory entrypoints. Do not move an example merely to change its website grouping.
+- **Add a row** to the table in this file for the corresponding category. `npm run test:example-catalog` fails when a catalog entry has no link in this README.
+- **Add exactly one entry** to [`catalog.json`](catalog.json), including its user goal, capability tags, format, level, and any directory entrypoints. The catalog is the machine-readable inventory and the website's classification contract; the directories above remain the maintenance taxonomy, and a catalog `goal` controls discovery by user intent without requiring a file move. The same command validates the metadata and fails when a standalone example or top-level example directory is not registered. Do not move an example merely to change its website grouping.
 - **Type-check before sending.** `npm run lint -w @open-multi-agent/core` compiles this directory together with `src/`, so an example that drifts from the current API fails CI. Examples with their own `package.json`/`tsconfig.json` are excluded from that pass and must be listed in [`tsconfig.lint.json`](../tsconfig.lint.json); they carry their own check instead.

--- a/packages/core/examples/basics/single-agent.ts
+++ b/packages/core/examples/basics/single-agent.ts
@@ -8,12 +8,22 @@
  *   npx tsx packages/core/examples/basics/single-agent.ts
  *
  * Prerequisites:
- *   ANTHROPIC_API_KEY env var must be set.
+ *   ANTHROPIC_API_KEY env var must be set (default provider). To use any
+ *   other built-in provider, set OMA_PROVIDER and OMA_MODEL plus that
+ *   provider's key, for example:
+ *     OMA_PROVIDER=deepseek OMA_MODEL=deepseek-chat DEEPSEEK_API_KEY=...
+ *     OMA_PROVIDER=openai OMA_MODEL=gpt-5.4 OPENAI_API_KEY=...
+ *   See docs/providers.md for the full provider and env var list.
  */
 
 import { join } from 'node:path'
-import { OpenMultiAgent, Agent, ToolRegistry, ToolExecutor, registerBuiltInTools } from '../../src/index.js'
+import { OpenMultiAgent, Agent, ToolRegistry, ToolExecutor, registerBuiltInTools, type SupportedProvider } from '../../src/index.js'
 import type { OrchestratorEvent } from '../../src/types.js'
+
+// Defaults to Claude. Any built-in provider works: set OMA_PROVIDER and
+// OMA_MODEL plus that provider's API key (see docs/providers.md).
+const provider = (process.env.OMA_PROVIDER ?? 'anthropic') as SupportedProvider
+const model = process.env.OMA_MODEL ?? 'claude-sonnet-4-6'
 
 // Built-in filesystem tools are sandboxed to `<cwd>/.agent-workspace` by
 // default; write example output there so the demo runs without disabling
@@ -26,7 +36,8 @@ const GREET_FILE = join(OUTPUT_DIR, 'greet.ts')
 // ---------------------------------------------------------------------------
 
 const orchestrator = new OpenMultiAgent({
-  defaultModel: 'claude-sonnet-4-6',
+  defaultProvider: provider,
+  defaultModel: model,
   onProgress: (event: OrchestratorEvent) => {
     if (event.type === 'agent_start') {
       console.log(`[start]    agent=${event.agent}`)
@@ -41,7 +52,8 @@ console.log('Part 1: runAgent() — single one-shot task\n')
 const result = await orchestrator.runAgent(
   {
     name: 'coder',
-    model: 'claude-sonnet-4-6',
+    provider,
+    model,
     systemPrompt: `You are a focused TypeScript developer.
 When asked to implement something, write clean, minimal code with no extra commentary.
 Use the bash tool to run commands and the file tools to read/write files.`,
@@ -87,7 +99,8 @@ const executor = new ToolExecutor(registry)
 const streamingAgent = new Agent(
   {
     name: 'explainer',
-    model: 'claude-sonnet-4-6',
+    provider,
+    model,
     systemPrompt: 'You are a concise technical writer. Keep explanations brief.',
     maxTurns: 3,
   },
@@ -118,7 +131,8 @@ console.log('\nPart 3: Agent.prompt() — multi-turn conversation\n')
 const conversationAgent = new Agent(
   {
     name: 'tutor',
-    model: 'claude-sonnet-4-6',
+    provider,
+    model,
     systemPrompt: 'You are a TypeScript tutor. Give short, direct answers.',
     maxTurns: 2,
     // Keep only the most recent turn in long prompt() conversations.

--- a/packages/core/examples/basics/structured-input.ts
+++ b/packages/core/examples/basics/structured-input.ts
@@ -8,14 +8,25 @@
  *   npx tsx packages/core/examples/basics/structured-input.ts ./photo.png
  *
  * Prerequisites:
- *   ANTHROPIC_API_KEY env var must be set.
+ *   ANTHROPIC_API_KEY env var must be set (default provider). To use any
+ *   other built-in provider, set OMA_PROVIDER and OMA_MODEL plus that
+ *   provider's key, for example:
+ *     OMA_PROVIDER=deepseek OMA_MODEL=deepseek-chat DEEPSEEK_API_KEY=...
+ *     OMA_PROVIDER=openai OMA_MODEL=gpt-5.4 OPENAI_API_KEY=...
+ *   The model must accept image input. See docs/providers.md for the full
+ *   provider and env var list.
  *   The image must be PNG, JPEG, GIF, or WebP.
  */
 
 import { readFile } from 'node:fs/promises'
 import { extname } from 'node:path'
 
-import { OpenMultiAgent, type LLMMessage } from '../../src/index.js'
+import { OpenMultiAgent, type LLMMessage, type SupportedProvider } from '../../src/index.js'
+
+// Defaults to Claude. Any built-in provider works: set OMA_PROVIDER and
+// OMA_MODEL plus that provider's API key (see docs/providers.md).
+const provider = (process.env.OMA_PROVIDER ?? 'anthropic') as SupportedProvider
+const model = process.env.OMA_MODEL ?? 'claude-sonnet-4-6'
 
 const imagePath = process.argv[2]
 if (!imagePath) {
@@ -61,8 +72,8 @@ const messages: LLMMessage[] = [
 ]
 
 const oma = new OpenMultiAgent({
-  defaultProvider: 'anthropic',
-  defaultModel: process.env.OMA_MODEL ?? 'claude-sonnet-4-6',
+  defaultProvider: provider,
+  defaultModel: model,
 })
 const result = await oma.runAgent({ name: 'vision-assistant' }, messages)
 

--- a/packages/core/examples/basics/task-pipeline.ts
+++ b/packages/core/examples/basics/task-pipeline.ts
@@ -11,12 +11,22 @@
  *   npx tsx packages/core/examples/basics/task-pipeline.ts
  *
  * Prerequisites:
- *   ANTHROPIC_API_KEY env var must be set.
+ *   ANTHROPIC_API_KEY env var must be set (default provider). To use any
+ *   other built-in provider, set OMA_PROVIDER and OMA_MODEL plus that
+ *   provider's key, for example:
+ *     OMA_PROVIDER=deepseek OMA_MODEL=deepseek-chat DEEPSEEK_API_KEY=...
+ *     OMA_PROVIDER=openai OMA_MODEL=gpt-5.4 OPENAI_API_KEY=...
+ *   See docs/providers.md for the full provider and env var list.
  */
 
 import { join } from 'node:path'
-import { OpenMultiAgent } from '../../src/index.js'
+import { OpenMultiAgent, type SupportedProvider } from '../../src/index.js'
 import type { AgentConfig, OrchestratorEvent, Task } from '../../src/types.js'
+
+// Defaults to Claude. Any built-in provider works: set OMA_PROVIDER and
+// OMA_MODEL plus that provider's API key (see docs/providers.md).
+const provider = (process.env.OMA_PROVIDER ?? 'anthropic') as SupportedProvider
+const model = process.env.OMA_MODEL ?? 'claude-sonnet-4-6'
 
 // Built-in filesystem tools are sandboxed to `<cwd>/.agent-workspace` by
 // default; pipeline output lives under that root so the demo runs without
@@ -31,7 +41,8 @@ const SPEC_FILE = join(OUTPUT_DIR, 'design-spec.md')
 
 const designer: AgentConfig = {
   name: 'designer',
-  model: 'claude-sonnet-4-6',
+  provider,
+  model,
   systemPrompt: `You are a software designer. Your output is always a concise technical spec
 in markdown. Focus on interfaces, data shapes, and file structure. Be brief.`,
   tools: ['file_write'],
@@ -40,7 +51,8 @@ in markdown. Focus on interfaces, data shapes, and file structure. Be brief.`,
 
 const implementer: AgentConfig = {
   name: 'implementer',
-  model: 'claude-sonnet-4-6',
+  provider,
+  model,
   systemPrompt: `You are a TypeScript developer. Read the design spec written by the designer,
 then implement it. Write all files to ${OUTPUT_DIR}/. Use the tools.`,
   tools: ['bash', 'file_read', 'file_write'],
@@ -49,7 +61,8 @@ then implement it. Write all files to ${OUTPUT_DIR}/. Use the tools.`,
 
 const tester: AgentConfig = {
   name: 'tester',
-  model: 'claude-sonnet-4-6',
+  provider,
+  model,
   systemPrompt: `You are a QA engineer. Read the implemented files and run them to verify correctness.
 Report: what passed, what failed, and any bugs found.`,
   tools: ['bash', 'file_read', 'grep'],
@@ -58,7 +71,8 @@ Report: what passed, what failed, and any bugs found.`,
 
 const reviewer: AgentConfig = {
   name: 'reviewer',
-  model: 'claude-sonnet-4-6',
+  provider,
+  model,
   systemPrompt: `You are a code reviewer. Read all files and produce a brief structured review.
 Sections: Summary, Strengths, Issues (if any), Verdict (SHIP / NEEDS WORK).`,
   tools: ['file_read', 'grep'],
@@ -106,7 +120,8 @@ function handleProgress(event: OrchestratorEvent): void {
 // ---------------------------------------------------------------------------
 
 const orchestrator = new OpenMultiAgent({
-  defaultModel: 'claude-sonnet-4-6',
+  defaultProvider: provider,
+  defaultModel: model,
   maxConcurrency: 2, // allow test + review to potentially run in parallel later
   onProgress: handleProgress,
 })

--- a/packages/core/examples/integrations/README.md
+++ b/packages/core/examples/integrations/README.md
@@ -3,7 +3,7 @@
 OMA wired to external systems: MCP servers, observability backends, other
 frameworks, app shells. Runnable starting points, not product docs.
 
-Two categories live here.
+Three categories live here.
 
 **Reference integrations** demonstrate wiring against widely used protocols
 or frameworks. The OMA team maintains these once merged, regardless of who
@@ -23,13 +23,24 @@ contributed them. Current:
   InMemory/File TraceStore, an application-owned OTel provider, and explicit
   CLI/server/serverless lifecycle handling. The original
   `trace-observability.ts` remains the legacy callback example.
-- `with-vercel-ai-sdk/`: Next.js + AI SDK + `runTeam()`.
+
+**Full applications** embed OMA in a real app shell. Each has its own
+`package.json` and start script (`npm install` then `npm start` or
+`npm run dev`) instead of `npx tsx`, and imports the published
+`@open-multi-agent/core` package name. The main index lists them under
+**apps**. Current:
+
 - `express-customer-support/`: Express REST API + `runTasks()`. Contributed
   by [@CodingBangboo](https://github.com/CodingBangboo) via #191.
+- `with-vercel-ai-sdk/`: Next.js + AI SDK + `runTeam()`.
 
 **Vendor integrations** show OMA paired with a specific third-party
-commercial product. They live under `with-<product>/` and stay credited to
-the contributor. Current:
+commercial product and stay credited to the contributor. Naming follows the
+shape of the example, not the vendor: a single-file script that wires one
+protocol or MCP server keeps the protocol prefix (`mcp-<server>.ts`, as with
+`mcp-bilig-workpaper.ts` and `mcp-open-design.ts` above), while a multi-file
+integration that ships its own store, toolkit, or app shell lives under
+`with-<product>/`. Current:
 
 - `with-engram/`: Engram memory backend. Contributed by
   [@Agentscreator](https://github.com/Agentscreator) via #160.

--- a/scripts/example-catalog-lib.mjs
+++ b/scripts/example-catalog-lib.mjs
@@ -128,6 +128,14 @@ export function discoverDocumentedEntrypoints(entry, examplesRoot) {
     .sort()
 }
 
+export function compareReadmeCoverage(entries, readmeText) {
+  return entries
+    .filter((entry) => typeof entry?.path === 'string')
+    .filter((entry) => !readmeText.includes(`](${entry.path})`) && !readmeText.includes(`](${entry.path}/)`))
+    .map((entry) => entry.path)
+    .sort()
+}
+
 export function compareCatalogInventory(entries, discoveredPaths) {
   const catalogPaths = new Set(entries.map((entry) => entry.path))
   const discovered = new Set(discoveredPaths)
@@ -347,6 +355,11 @@ export function validateExampleCatalog(catalog, examplesRoot) {
   }
   for (const path of inventory.missingFromFilesystem) {
     errors.push(`catalog path is not a discovered example unit: ${path}`)
+  }
+  const readmePath = join(examplesRoot, 'README.md')
+  const readmeText = existsSync(readmePath) ? readFileSync(readmePath, 'utf8') : ''
+  for (const path of compareReadmeCoverage(catalog.examples, readmeText)) {
+    errors.push(`example is not linked from examples/README.md: ${path}`)
   }
   for (const entry of catalog.examples) {
     if (entry && typeof entry === 'object') {

--- a/scripts/example-catalog.test.mjs
+++ b/scripts/example-catalog.test.mjs
@@ -9,6 +9,7 @@ import {
   EXAMPLE_LEVELS,
   EXAMPLE_SECTIONS,
   compareCatalogInventory,
+  compareReadmeCoverage,
   discoverDocumentedEntrypoints,
   discoverExampleUnits,
   readCatalog,
@@ -66,6 +67,25 @@ test('multi-file suites register every self-documented runnable entrypoint', () 
   assert.deepEqual(
     discoverDocumentedEntrypoints(engram, examplesRoot),
     [...engram.entrypoints].sort(),
+  )
+})
+
+test('README coverage reports catalog entries with no link in the index', () => {
+  const readme = [
+    '| [`basics/single-agent`](basics/single-agent.ts) | row |',
+    '| [`integrations/observability-v2/`](integrations/observability-v2/) | row |',
+  ].join('\n')
+  assert.deepEqual(
+    compareReadmeCoverage(
+      [
+        { path: 'basics/single-agent.ts' },
+        { path: 'integrations/observability-v2' },
+        { path: 'integrations/with-engram' },
+        { path: 'patterns/unlisted.ts' },
+      ],
+      readme,
+    ),
+    ['integrations/with-engram', 'patterns/unlisted.ts'],
   )
 })
 


### PR DESCRIPTION
## Why

`packages/core/examples` is the most visited page after the root README and README_zh (GitHub traffic, last 14 days). A visitor landing there today cannot tell that the scripts need a repository checkout, which examples run without an API key, or that four integrations exist, because the index never mentioned them.

## What changed

**Getting to a running example**

- New "Run an example" block at the top: clone, `npm install`, export the key, `npx tsx`. It states that scripts import `../../src/index.js`, that `integrations/observability-v2/` needs `npm run build` first, that the full applications use their own start scripts, and how to port a script into a project that installs `@open-multi-agent/core`.
- New "No API key needed" table listing the seven offline examples (durable-approval, event-driven-dag, both eval examples, commission-reconciliation-recovery, observability-v2, gemma4-local).
- `basics/single-agent`, `basics/structured-input`, and `basics/task-pipeline` now read `OMA_PROVIDER` and `OMA_MODEL`, defaulting to Claude as before. This is the same convention `cookbook/adaptive-customer-support` already uses, so a visitor with only a DeepSeek or OpenAI key can run the "start here" scripts. `basics/multi-model-team` keeps its two providers on purpose.

**Keeping the index complete**

- Added the four examples that were in the directory and in `catalog.json` but not in the index: `external-agent-acp`, `external-agent-process`, `with-engram/`, `with-tencentdb-memory/`.
- `scripts/example-catalog-lib.mjs` gains `compareReadmeCoverage`; `npm run test:example-catalog` now fails when a catalog entry has no link in `examples/README.md`. Covered by a unit test and checked against the real catalog with one link removed.

**Readability**

- Sections reordered to basics, cookbook, patterns, integrations, apps, providers, production, so the 20-row providers table no longer sits between basics and the tables most visitors came for.
- `production/` is marked as currently empty, with the cookbook named as the closest alternative. The acceptance criteria file is unchanged and still linked from the root and core READMEs.
- Cookbook descriptions trimmed to one line each; the catalog maintenance paragraph moved from the first screen to "Adding a new example".
- `integrations/README.md` now has a "Full applications" group matching the index's apps section, and defines the naming rule by example shape: `mcp-<server>.ts` for single-file protocol wiring, `with-<product>/` for multi-file vendor integrations. No files move, so external deep links keep working.

## Verification

- `npm run test:example-catalog`: 10 tests pass, 64 entries validated
- `npm run lint -w @open-multi-agent/core`: pass (type-checks the edited basics scripts with `src/`)
- `git diff --check`: clean

Not run: the three basics scripts against a live provider. The change replaces model literals with variables and passes `provider` through; the type check covers the shape.
