### PR TITLE
fix(release-bot): name otel in the title and @-mention credited logins

### DIFF
--- a/packages/release-bot/src/apply-plan.ts
+++ b/packages/release-bot/src/apply-plan.ts
@@ -120,8 +120,14 @@ export interface ReleasePackageSummary {
 
 /** One outside contributor and what they landed in this release. */
 export interface ReleaseContributor {
-  /** GitHub login when the commit carried a noreply address, else the author name. */
+  /** GitHub login when one was resolved, else the author's display name. */
   readonly name: string
+  /**
+   * Whether {@link name} is a GitHub login rather than a display name, which
+   * decides whether it is safe to @-mention. See the Thanks section in
+   * {@link composeReleaseBody}.
+   */
+  readonly isLogin: boolean
   /** What they landed, one entry per merged commit, already stripped of its type prefix. */
   readonly contributions: readonly string[]
 }
@@ -158,11 +164,18 @@ export function composeReleaseBody(input: ReleaseBodyInput): string {
     return `- \`${item.name}\`: \`${item.version}\``
   })
 
-  // Plain names, never `@handle`: a release body that mentions an account
-  // notifies it, and this text is published without the person reviewing it.
+  // @-mention a contributor so the credit reaches them, but only when the name
+  // is a login GitHub itself confirmed. A display name is not a handle and can
+  // belong to someone else: v1.17.0 credited `s4kura` for #549 when the author
+  // was `Iams4kura`. As plain text that was a wrong name; as an @-mention it
+  // would have notified an uninvolved stranger, in a body this bot publishes
+  // without anyone reviewing it first. So the display-name fallback stays plain.
   const thanks = (input.contributors ?? [])
     .filter(contributor => contributor.contributions.length > 0)
-    .map(contributor => `- ${contributor.name}: ${contributor.contributions.join('; ')}`)
+    .map(contributor => {
+      const credit = contributor.isLogin ? `@${contributor.name}` : contributor.name
+      return `- ${credit}: ${contributor.contributions.join('; ')}`
+    })
   const thanksSection = thanks.length > 0 ? `\n## Thanks\n\n${thanks.join('\n')}\n` : ''
 
   return `${input.notes}
@@ -180,8 +193,24 @@ npm create oma-app@latest my-oma
 `
 }
 
+/**
+ * The title names every package this release publishes.
+ *
+ * It used to hard-code core and create-oma-app, so a release that republished
+ * otel never said so: v1.18.0 shipped otel 0.1.3 under a title that named two
+ * packages. otel is the only conditional one, because a release always moves
+ * core and create-oma-app, and `bumps.otel === null` is the same signal the
+ * body's package table already switches on.
+ *
+ * The `chore: release core vX.Y.Z` prefix is load-bearing and must stay first:
+ * `prepareReleasePr` recognizes an already-open release PR by it, and this
+ * string is also the release commit subject.
+ */
 export function buildReleasePrTitle(plan: ReleasePlan): string {
-  return `chore: release core v${plan.nextVersions.core} and create-oma-app v${plan.nextVersions.createOmaApp}`
+  const core = `core v${plan.nextVersions.core}`
+  const scaffolder = `create-oma-app v${plan.nextVersions.createOmaApp}`
+  if (plan.bumps.otel === null) return `chore: release ${core} and ${scaffolder}`
+  return `chore: release ${core}, otel v${plan.nextVersions.otel}, and ${scaffolder}`
 }
 
 export function buildReleasePrBody(plan: ReleasePlan): string {

--- a/packages/release-bot/src/publisher.ts
+++ b/packages/release-bot/src/publisher.ts
@@ -208,21 +208,21 @@ export async function collectReleaseContributors(
     { cwd: options.repoRoot },
   )
   const excluded = new Set(options.excludedContributors ?? DEFAULT_EXCLUDED_CONTRIBUTORS)
-  const byName = new Map<string, string[]>()
+  const byName = new Map<string, { isLogin: boolean; contributions: string[] }>()
   const loginByEmail = new Map<string, string | null>()
   for (const record of log.stdout.split('\u001e')) {
     const line = record.trim()
     if (line === '') continue
     const [sha = '', author = '', email = '', subject = ''] = line.split('\u001f')
-    const name = await resolveContributorName(sha, author, email, options.github, loginByEmail)
+    const { name, isLogin } = await resolveContributorName(sha, author, email, options.github, loginByEmail)
     if (name === '' || name.endsWith('[bot]') || excluded.has(name)) continue
     const contribution = describeContribution(subject)
     if (contribution === '') continue
     const existing = byName.get(name)
-    if (existing) existing.push(contribution)
-    else byName.set(name, [contribution])
+    if (existing) existing.contributions.push(contribution)
+    else byName.set(name, { isLogin, contributions: [contribution] })
   }
-  return [...byName].map(([name, contributions]) => ({ name, contributions }))
+  return [...byName].map(([name, entry]) => ({ name, isLogin: entry.isLogin, contributions: entry.contributions }))
 }
 
 /**
@@ -240,6 +240,10 @@ export async function collectReleaseContributors(
  * function had before, rather than failing a publish over a name. The result
  * is cached per address, so a contributor with several commits costs one
  * request and a transient failure degrades that contributor consistently.
+ *
+ * `isLogin` reports which of those happened, because the release body may only
+ * @-mention a confirmed login. A degraded display name is credited as plain
+ * text rather than used to notify whichever account happens to hold it.
  */
 async function resolveContributorName(
   sha: string,
@@ -247,16 +251,18 @@ async function resolveContributorName(
   email: string,
   github: GitHubClient | undefined,
   loginByEmail: Map<string, string | null>,
-): Promise<string> {
+): Promise<{ readonly name: string; readonly isLogin: boolean }> {
   const address = email.trim()
   const noreply = /^(?:\d+\+)?(.+)@users\.noreply\.github\.com$/.exec(address)
-  if (noreply?.[1]) return noreply[1].trim()
-  if (!github || sha === '') return author.trim()
+  if (noreply?.[1]) return { name: noreply[1].trim(), isLogin: true }
+  if (!github || sha === '') return { name: author.trim(), isLogin: false }
 
   if (!loginByEmail.has(address)) {
     loginByEmail.set(address, await github.getCommitAuthorLogin(sha).catch(() => null))
   }
-  return (loginByEmail.get(address) ?? author).trim()
+  const login = loginByEmail.get(address)
+  if (login) return { name: login.trim(), isLogin: true }
+  return { name: author.trim(), isLogin: false }
 }
 
 /** `feat(examples): add a thing (#12)` becomes `add a thing (#12)`. */

--- a/packages/release-bot/tests/apply-plan.test.ts
+++ b/packages/release-bot/tests/apply-plan.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   applyReleasePlan,
   buildReleasePrBody,
+  buildReleasePrTitle,
   composeReleaseBody,
   insertReleaseEntry,
   renderReleaseNotes,
@@ -118,6 +119,31 @@ describe('release plan materialization', () => {
     expect(body).toContain('Version calculation, template pins')
     expect(body).toContain('Merging this PR is the human release approval')
   })
+
+  it('titles a two-package release with core and the scaffolder', () => {
+    expect(buildReleasePrTitle(plan)).toBe('chore: release core v1.15.0 and create-oma-app v0.8.0')
+  })
+
+  it('names otel in the title when otel is part of the release', () => {
+    // v1.18.0 published otel 0.1.3 under a title that named two packages,
+    // because the title hard-coded them while the body's table did not.
+    const otelPlan: ReleasePlan = {
+      ...plan,
+      nextVersions: { ...plan.nextVersions, otel: '0.1.2' },
+      bumps: { ...plan.bumps, otel: 'patch' },
+    }
+
+    expect(buildReleasePrTitle(otelPlan))
+      .toBe('chore: release core v1.15.0, otel v0.1.2, and create-oma-app v0.8.0')
+  })
+
+  it('keeps the prefix prepareReleasePr matches on in both shapes', () => {
+    const otelPlan: ReleasePlan = { ...plan, bumps: { ...plan.bumps, otel: 'patch' } }
+    const prefix = /^chore: release core v\d+\.\d+\.\d+\b/i
+
+    expect(buildReleasePrTitle(plan)).toMatch(prefix)
+    expect(buildReleasePrTitle(otelPlan)).toMatch(prefix)
+  })
 })
 
 async function createFixture(): Promise<string> {
@@ -193,6 +219,32 @@ describe('published release body', () => {
       .filter(line => line.length > 0 && /^\s+\S/.test(line))
 
     expect(continuations).toEqual([])
+  })
+
+  it('@-mentions a contributor whose name is a confirmed GitHub login', () => {
+    const body = composeReleaseBody({
+      notes: '### Added\n\n- Something.',
+      coreVersion: '1.15.0',
+      packages,
+      contributors: [{ name: 'green3sf', isLogin: true, contributions: ['add a verify loop (#541)'] }],
+    })
+
+    expect(body).toContain('- @green3sf: add a verify loop (#541)')
+  })
+
+  it('leaves a display-name fallback unmentioned so it cannot notify a stranger', () => {
+    // v1.17.0 credited `s4kura` for #549 when the author was `Iams4kura`. An
+    // unresolved display name is not a handle, and this body is published
+    // without anyone reviewing it, so it must never become an @-mention.
+    const body = composeReleaseBody({
+      notes: '### Added\n\n- Something.',
+      coreVersion: '1.15.0',
+      packages,
+      contributors: [{ name: 'Ada Lovelace', isLogin: false, contributions: ['tighten a guard (#12)'] }],
+    })
+
+    expect(body).toContain('- Ada Lovelace: tighten a guard (#12)')
+    expect(body).not.toContain('@Ada Lovelace')
   })
 
   it('refuses a package set that does not carry core', () => {

--- a/packages/release-bot/tests/publisher.test.ts
+++ b/packages/release-bot/tests/publisher.test.ts
@@ -61,7 +61,7 @@ describe('deterministic publisher', () => {
     expect(body).toContain('@open-multi-agent/core@1.15.0')
     // Outside contributors only: the maintainer and the bot are filtered out.
     expect(body).toContain('## Thanks')
-    expect(body).toContain('- green3sf: add a verify loop (#541)')
+    expect(body).toContain('- @green3sf: add a verify loop (#541)')
     expect(body).not.toContain('Jack Chen')
     expect(body).not.toContain('oma-release-bot')
 
@@ -270,7 +270,7 @@ describe('release contributor collection', () => {
     } as Parameters<typeof collectReleaseContributors>[0])
 
     expect(contributors).toEqual([
-      { name: 'green3sf', contributions: ['add a verify loop (#541)', 'refresh output (#536)'] },
+      { name: 'green3sf', isLogin: true, contributions: ['add a verify loop (#541)', 'refresh output (#536)'] },
     ])
   })
 
@@ -284,7 +284,7 @@ describe('release contributor collection', () => {
     } as Parameters<typeof collectReleaseContributors>[0])
 
     expect(contributors).toEqual([
-      { name: 'Iams4kura', contributions: ['align required fields (#549)'] },
+      { name: 'Iams4kura', isLogin: true, contributions: ['align required fields (#549)'] },
     ])
   })
 
@@ -297,7 +297,7 @@ describe('release contributor collection', () => {
     } as Parameters<typeof collectReleaseContributors>[0])
 
     expect(calls).toEqual([])
-    expect(contributors).toEqual([{ name: 'green3sf', contributions: ['a fix (#1)'] }])
+    expect(contributors).toEqual([{ name: 'green3sf', isLogin: true, contributions: ['a fix (#1)'] }])
   })
 
   it('falls back to the author name when no account claims the commit', async () => {
@@ -308,7 +308,7 @@ describe('release contributor collection', () => {
     } as Parameters<typeof collectReleaseContributors>[0])
 
     expect(contributors).toEqual([
-      { name: 'Ada Lovelace', contributions: ['tighten a guard (#12)'] },
+      { name: 'Ada Lovelace', isLogin: false, contributions: ['tighten a guard (#12)'] },
     ])
   })
 
@@ -321,7 +321,7 @@ describe('release contributor collection', () => {
     } as Parameters<typeof collectReleaseContributors>[0])
 
     expect(contributors).toEqual([
-      { name: 'Ada Lovelace', contributions: ['tighten a guard (#12)'] },
+      { name: 'Ada Lovelace', isLogin: false, contributions: ['tighten a guard (#12)'] },
     ])
   })
 
@@ -332,7 +332,7 @@ describe('release contributor collection', () => {
     } as Parameters<typeof collectReleaseContributors>[0])
 
     expect(contributors).toEqual([
-      { name: 'Ada Lovelace', contributions: ['tighten a guard (#12)'] },
+      { name: 'Ada Lovelace', isLogin: false, contributions: ['tighten a guard (#12)'] },
     ])
   })
 
@@ -349,7 +349,7 @@ describe('release contributor collection', () => {
 
     expect(calls).toEqual(['a'.repeat(40)])
     expect(contributors).toEqual([
-      { name: 'Iams4kura', contributions: ['first (#1)', 'second (#2)'] },
+      { name: 'Iams4kura', isLogin: true, contributions: ['first (#1)', 'second (#2)'] },
     ])
   })
 


### PR DESCRIPTION
Two things the v1.18.0 release surfaced, both in text the bot publishes on its own.

## The title could never name otel

`buildReleasePrTitle` hard-coded core and create-oma-app, so a release that also republished otel had no way to say so. v1.18.0 shipped `@open-multi-agent/otel` 0.1.3 under a title naming two packages, and the same title becomes the release commit subject, so the omission is now permanent in `main`'s history.

The signal was already there. `buildReleasePrBody` switches its package table on `bumps.otel === null`; only the title ignored it. The title now reads the same condition:

```
without otel:  chore: release core v1.19.0 and create-oma-app v0.8.5
with otel:     chore: release core v1.19.0, otel v0.1.4, and create-oma-app v0.8.5
```

The two-package string is unchanged byte for byte. A test pins the `chore: release core vX.Y.Z` prefix in both shapes, because `prepareReleasePr` recognizes an already-open release PR by that prefix and the title doubles as the release commit subject, so it cannot drift.

## Thanks credited contributors without reaching them

The Thanks section rendered plain names, which meant the section thanked people who were never told. Contributors are now `@`-mentioned so the credit actually arrives.

The mention is conditional, and deliberately so. `resolveContributorName` has three paths: a GitHub noreply address that already carries the login, an API lookup asking which account claims the commit, and a fallback to the git display name when the address is unlinked, the client is missing, or the request fails. Only the first two produce a real handle.

v1.17.0 took that third path and credited `s4kura` for #549 when the author was `Iams4kura`, an account someone else holds. As plain text that was a wrong name. As an `@`-mention it would have notified an uninvolved stranger, in a release body this bot publishes without anyone reviewing it first, and a published release body is not something you can quietly take back.

So `ReleaseContributor` now carries `isLogin` out of all three paths, and only a confirmed login is mentioned:

```
- @octo-patch: add video input (#548)
- Ada Lovelace: tighten a guard (#12)
```

## Tests

Five new cases: the two-package title, the three-package title, the prefix invariant across both shapes, an `@`-mention for a confirmed login, and a plain credit for a display-name fallback. The last one carries the `s4kura` incident in a comment so the fallback does not quietly become a mention later. The seven existing contributor-resolution tests now assert `isLogin` alongside the name, which is what keeps the three paths distinguishable.

## Verification

`npm run lint`, `npm test`, and `npm run build` for `@open-multi-agent/release-bot` all pass, 59 tests. Nothing outside that workspace changed, and the released packages are untouched.

Beyond the tests, both renderers were called directly against a plan and a contributor list to confirm the strings above are the real output rather than an expectation written to match the code.
