### PR TITLE
docs(readme): keep the first screen to title, tagline, badges, and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,31 +21,6 @@
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
 </p>
 
-```typescript
-import { FileStore, OpenMultiAgent } from '@open-multi-agent/core'
-
-// Your keys and your endpoint: a hosted provider, or a local server through baseURL.
-const oma = new OpenMultiAgent({
-  defaultProvider: 'openai',
-  defaultModel: 'gpt-5.4',
-  // Consequential tool calls (file writes, shell) pause for a human decision.
-  onToolCall: ({ consequential }) => (consequential ? { action: 'suspend' } : { action: 'allow' }),
-})
-
-const team = oma.createTeam('ops', {
-  name: 'ops',
-  agents: [{ name: 'operator', systemPrompt: 'Reconcile overdue invoices.', toolPreset: 'readwrite' }],
-})
-
-// The coordinator plans the task DAG from the goal; the checkpoint store keeps the run durable.
-const result = await oma.runTeam(team, 'Find overdue invoices and draft the reminders.', {
-  checkpoint: { store: new FileStore('./.oma/run.json') },
-})
-
-// result.status?.code === 'suspended' until a reviewer decides result.pendingApprovals,
-// each bound to a hash of exactly what the reviewer was shown.
-```
-
 <p align="center">
   <a href="https://open-multi-agent.com/?utm_source=github&utm_medium=readme">Website</a> ·
   <a href="https://open-multi-agent.com/getting-started/introduction/?utm_source=github&utm_medium=readme">Docs</a> ·
@@ -128,6 +103,36 @@ for (const task of result.tasks ?? []) {
 
 console.log(result.agentResults.get('coordinator')?.output)
 console.log(result.totalTokenUsage)
+```
+
+</details>
+
+<details>
+<summary>Pause consequential tool calls for approval</summary>
+
+```typescript
+import { FileStore, OpenMultiAgent } from '@open-multi-agent/core'
+
+// Your keys and your endpoint: a hosted provider, or a local server through baseURL.
+const oma = new OpenMultiAgent({
+  defaultProvider: 'openai',
+  defaultModel: 'gpt-5.4',
+  // Consequential tool calls (file writes, shell) pause for a human decision.
+  onToolCall: ({ consequential }) => (consequential ? { action: 'suspend' } : { action: 'allow' }),
+})
+
+const team = oma.createTeam('ops', {
+  name: 'ops',
+  agents: [{ name: 'operator', systemPrompt: 'Reconcile overdue invoices.', toolPreset: 'readwrite' }],
+})
+
+// The coordinator plans the task DAG from the goal; the checkpoint store keeps the run durable.
+const result = await oma.runTeam(team, 'Find overdue invoices and draft the reminders.', {
+  checkpoint: { store: new FileStore('./.oma/run.json') },
+})
+
+// result.status?.code === 'suspended' until a reviewer decides result.pendingApprovals,
+// each bound to a hash of exactly what the reviewer was shown.
 ```
 
 </details>

--- a/README_zh.md
+++ b/README_zh.md
@@ -21,31 +21,6 @@
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
 </p>
 
-```typescript
-import { FileStore, OpenMultiAgent } from '@open-multi-agent/core'
-
-// 密钥与端点都是你自己的：托管模型，或通过 baseURL 接本地服务。
-const oma = new OpenMultiAgent({
-  defaultProvider: 'openai',
-  defaultModel: 'gpt-5.4',
-  // 有实际副作用的工具调用（写文件、执行 shell）挂起，等待人工决定。
-  onToolCall: ({ consequential }) => (consequential ? { action: 'suspend' } : { action: 'allow' }),
-})
-
-const team = oma.createTeam('ops', {
-  name: 'ops',
-  agents: [{ name: 'operator', systemPrompt: '核对逾期发票。', toolPreset: 'readwrite' }],
-})
-
-// Coordinator 从目标规划任务 DAG；checkpoint store 让整次运行可持久化。
-const result = await oma.runTeam(team, '找出逾期发票并起草催款提醒。', {
-  checkpoint: { store: new FileStore('./.oma/run.json') },
-})
-
-// 在审批人处理 result.pendingApprovals 之前，result.status?.code 保持为 'suspended'；
-// 每条待审批请求都绑定审批人实际看到内容的哈希。
-```
-
 <p align="center">
   <a href="https://open-multi-agent.com/zh/?utm_source=github&utm_medium=readme">官网</a> ·
   <a href="https://open-multi-agent.com/zh/getting-started/introduction/?utm_source=github&utm_medium=readme">文档</a> ·
@@ -127,6 +102,36 @@ for (const task of result.tasks ?? []) {
 
 console.log(result.agentResults.get('coordinator')?.output)
 console.log(result.totalTokenUsage)
+```
+
+</details>
+
+<details>
+<summary>让有副作用的工具调用挂起等待审批</summary>
+
+```typescript
+import { FileStore, OpenMultiAgent } from '@open-multi-agent/core'
+
+// 密钥与端点都是你自己的：托管模型，或通过 baseURL 接本地服务。
+const oma = new OpenMultiAgent({
+  defaultProvider: 'openai',
+  defaultModel: 'gpt-5.4',
+  // 有实际副作用的工具调用（写文件、执行 shell）挂起，等待人工决定。
+  onToolCall: ({ consequential }) => (consequential ? { action: 'suspend' } : { action: 'allow' }),
+})
+
+const team = oma.createTeam('ops', {
+  name: 'ops',
+  agents: [{ name: 'operator', systemPrompt: '核对逾期发票。', toolPreset: 'readwrite' }],
+})
+
+// Coordinator 从目标规划任务 DAG；checkpoint store 让整次运行可持久化。
+const result = await oma.runTeam(team, '找出逾期发票并起草催款提醒。', {
+  checkpoint: { store: new FileStore('./.oma/run.json') },
+})
+
+// 在审批人处理 result.pendingApprovals 之前，result.status?.code 保持为 'suspended'；
+// 每条待审批请求都绑定审批人实际看到内容的哈希。
 ```
 
 </details>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -21,31 +21,6 @@
   <a href="https://codecov.io/gh/open-multi-agent/open-multi-agent"><img src="https://codecov.io/gh/open-multi-agent/open-multi-agent/graph/badge.svg" alt="codecov"></a>
 </p>
 
-```typescript
-import { FileStore, OpenMultiAgent } from '@open-multi-agent/core'
-
-// Your keys and your endpoint: a hosted provider, or a local server through baseURL.
-const oma = new OpenMultiAgent({
-  defaultProvider: 'openai',
-  defaultModel: 'gpt-5.4',
-  // Consequential tool calls (file writes, shell) pause for a human decision.
-  onToolCall: ({ consequential }) => (consequential ? { action: 'suspend' } : { action: 'allow' }),
-})
-
-const team = oma.createTeam('ops', {
-  name: 'ops',
-  agents: [{ name: 'operator', systemPrompt: 'Reconcile overdue invoices.', toolPreset: 'readwrite' }],
-})
-
-// The coordinator plans the task DAG from the goal; the checkpoint store keeps the run durable.
-const result = await oma.runTeam(team, 'Find overdue invoices and draft the reminders.', {
-  checkpoint: { store: new FileStore('./.oma/run.json') },
-})
-
-// result.status?.code === 'suspended' until a reviewer decides result.pendingApprovals,
-// each bound to a hash of exactly what the reviewer was shown.
-```
-
 <p align="center">
   <a href="https://open-multi-agent.com/?utm_source=npm&utm_medium=package_readme">Website</a> ·
   <a href="https://open-multi-agent.com/getting-started/introduction/?utm_source=npm&utm_medium=package_readme">Docs</a> ·
@@ -108,6 +83,36 @@ const team = orchestrator.createTeam('research-team', {
 const result = await orchestrator.runTeam(team, 'Compare three approaches and recommend one.')
 console.log(result.agentResults.get('coordinator')?.output)
 ```
+
+<details>
+<summary>Pause consequential tool calls for approval</summary>
+
+```typescript
+import { FileStore, OpenMultiAgent } from '@open-multi-agent/core'
+
+// Your keys and your endpoint: a hosted provider, or a local server through baseURL.
+const oma = new OpenMultiAgent({
+  defaultProvider: 'openai',
+  defaultModel: 'gpt-5.4',
+  // Consequential tool calls (file writes, shell) pause for a human decision.
+  onToolCall: ({ consequential }) => (consequential ? { action: 'suspend' } : { action: 'allow' }),
+})
+
+const team = oma.createTeam('ops', {
+  name: 'ops',
+  agents: [{ name: 'operator', systemPrompt: 'Reconcile overdue invoices.', toolPreset: 'readwrite' }],
+})
+
+// The coordinator plans the task DAG from the goal; the checkpoint store keeps the run durable.
+const result = await oma.runTeam(team, 'Find overdue invoices and draft the reminders.', {
+  checkpoint: { store: new FileStore('./.oma/run.json') },
+})
+
+// result.status?.code === 'suspended' until a reviewer decides result.pendingApprovals,
+// each bound to a hash of exactly what the reviewer was shown.
+```
+
+</details>
 
 Set `OPENAI_API_KEY` for this example. For other hosted or local models, see [Providers](#providers).
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -21,31 +21,6 @@
   <a href="https://codecov.io/gh/open-multi-agent/open-multi-agent"><img src="https://codecov.io/gh/open-multi-agent/open-multi-agent/graph/badge.svg" alt="codecov"></a>
 </p>
 
-```typescript
-import { FileStore, OpenMultiAgent } from '@open-multi-agent/core'
-
-// 密钥与端点都是你自己的：托管模型，或通过 baseURL 接本地服务。
-const oma = new OpenMultiAgent({
-  defaultProvider: 'openai',
-  defaultModel: 'gpt-5.4',
-  // 有实际副作用的工具调用（写文件、执行 shell）挂起，等待人工决定。
-  onToolCall: ({ consequential }) => (consequential ? { action: 'suspend' } : { action: 'allow' }),
-})
-
-const team = oma.createTeam('ops', {
-  name: 'ops',
-  agents: [{ name: 'operator', systemPrompt: '核对逾期发票。', toolPreset: 'readwrite' }],
-})
-
-// Coordinator 从目标规划任务 DAG；checkpoint store 让整次运行可持久化。
-const result = await oma.runTeam(team, '找出逾期发票并起草催款提醒。', {
-  checkpoint: { store: new FileStore('./.oma/run.json') },
-})
-
-// 在审批人处理 result.pendingApprovals 之前，result.status?.code 保持为 'suspended'；
-// 每条待审批请求都绑定审批人实际看到内容的哈希。
-```
-
 <p align="center">
   <a href="https://open-multi-agent.com/zh/?utm_source=github&utm_medium=package_readme">官网</a> ·
   <a href="https://open-multi-agent.com/zh/getting-started/introduction/?utm_source=github&utm_medium=package_readme">文档</a> ·
@@ -108,6 +83,36 @@ const team = orchestrator.createTeam('research-team', {
 const result = await orchestrator.runTeam(team, 'Compare three approaches and recommend one.')
 console.log(result.agentResults.get('coordinator')?.output)
 ```
+
+<details>
+<summary>让有副作用的工具调用挂起等待审批</summary>
+
+```typescript
+import { FileStore, OpenMultiAgent } from '@open-multi-agent/core'
+
+// 密钥与端点都是你自己的：托管模型，或通过 baseURL 接本地服务。
+const oma = new OpenMultiAgent({
+  defaultProvider: 'openai',
+  defaultModel: 'gpt-5.4',
+  // 有实际副作用的工具调用（写文件、执行 shell）挂起，等待人工决定。
+  onToolCall: ({ consequential }) => (consequential ? { action: 'suspend' } : { action: 'allow' }),
+})
+
+const team = oma.createTeam('ops', {
+  name: 'ops',
+  agents: [{ name: 'operator', systemPrompt: '核对逾期发票。', toolPreset: 'readwrite' }],
+})
+
+// Coordinator 从目标规划任务 DAG；checkpoint store 让整次运行可持久化。
+const result = await oma.runTeam(team, '找出逾期发票并起草催款提醒。', {
+  checkpoint: { store: new FileStore('./.oma/run.json') },
+})
+
+// 在审批人处理 result.pendingApprovals 之前，result.status?.code 保持为 'suspended'；
+// 每条待审批请求都绑定审批人实际看到内容的哈希。
+```
+
+</details>
 
 该示例需要设置 `OPENAI_API_KEY`。其他云端或本地模型见 [Provider](#provider)。
 


### PR DESCRIPTION
## Summary

Removes the code sample from the README first screen so the top of the page is the title block, the tagline, the badges, and the navigation links. The sample itself is kept: it moves under the getting-started section as a collapsed block, next to the existing full example, so the approval and checkpoint usage stays one click away without competing with the minimal example that follows the badges.

All four README copies change together (root and package, English and Chinese).

## Changes

- First screen: the TypeScript block between the badges and the Website / Docs / Examples / npm links is removed.
- Root READMEs: the same sample now sits in a second `<details>` block after "Full example: DAG readback, token usage, and model overrides", titled "Pause consequential tool calls for approval" (Chinese: 让有副作用的工具调用挂起等待审批).
- Package READMEs: the sample sits in a `<details>` block directly after the Quick Start sample, with the same title.
- No wording inside the sample changes; it is the block that was type-checked in #581.

## Validation

- `git diff --check`: clean.
- Documentation-only change; no tests run, per the validation rules in AGENTS.md.
