### PR TITLE
chore: update copyright and maintainer attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Changed
+
+- LICENSE now names Shenzhen YuanASI Technology Co., Ltd. alongside the
+  open-multi-agent contributors, every package README closes with a maintainer
+  line linking to yuanasi.com, and `author` in the three published package.json
+  files points at YuanASI. The MIT terms are unchanged.
+
 ## 1.18.0 - 2026-09-04
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,8 @@
 
 `open-multi-agent` is built by the people below. The [contributor graph](https://github.com/open-multi-agent/open-multi-agent/graphs/contributors) lists everyone who has landed a commit; this file records what each person contributed.
 
+The project is maintained by [YuanASI (Shenzhen YuanASI Technology Co., Ltd.)](https://yuanasi.com/en); Jack Chen is the lead maintainer.
+
 Opening your first PR gets you added here. See the [contribution guide](.github/CONTRIBUTING.md).
 
 ## Framework features

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) open-multi-agent contributors
+Copyright (c) Shenzhen YuanASI Technology Co., Ltd. and open-multi-agent contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -231,3 +231,5 @@ Contributor credits by area are in [CONTRIBUTORS.md](CONTRIBUTORS.md).
 ## License
 
 MIT
+
+Maintained by [YuanASI (Shenzhen YuanASI Technology Co., Ltd.)](https://yuanasi.com/en?utm_source=github&utm_medium=readme_footer&utm_campaign=open_multi_agent).

--- a/README_zh.md
+++ b/README_zh.md
@@ -232,3 +232,5 @@ Core 用户可以在本地保存 trace，并用离线 Run Viewer 查看。只有
 ## 许可证
 
 MIT
+
+由[深圳元定义科技有限公司（YuanASI）](https://yuanasi.com/?utm_source=github&utm_medium=readme_footer&utm_campaign=open_multi_agent)维护。

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) open-multi-agent contributors
+Copyright (c) Shenzhen YuanASI Technology Co., Ltd. and open-multi-agent contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -319,3 +319,5 @@ Per-contributor credits by area are in [CONTRIBUTORS.md](https://github.com/open
 ## License
 
 MIT
+
+Maintained by [YuanASI (Shenzhen YuanASI Technology Co., Ltd.)](https://yuanasi.com/en?utm_source=npm&utm_medium=package_readme&utm_campaign=open_multi_agent).

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -302,3 +302,5 @@ Core 已提供运行标识、trace sink、执行回执、可查询的内存/文�
 ## 许可证
 
 MIT
+
+由[深圳元定义科技有限公司（YuanASI）](https://yuanasi.com/?utm_source=github&utm_medium=package_readme&utm_campaign=open_multi_agent)维护。

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,8 +88,9 @@
     "agent-framework"
   ],
   "author": {
-    "name": "open-multi-agent",
-    "url": "https://github.com/open-multi-agent"
+    "name": "YuanASI (Shenzhen YuanASI Technology Co., Ltd.)",
+    "email": "co@yuanasi.com",
+    "url": "https://yuanasi.com"
   },
   "license": "MIT",
   "repository": {

--- a/packages/create-oma-app/LICENSE
+++ b/packages/create-oma-app/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 open-multi-agent contributors
+Copyright (c) Shenzhen YuanASI Technology Co., Ltd. and open-multi-agent contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/create-oma-app/README.md
+++ b/packages/create-oma-app/README.md
@@ -55,3 +55,5 @@ Ollama projects select `OMA_MODEL` when set, otherwise the first installed model
 ## License
 
 MIT
+
+Maintained by [YuanASI (Shenzhen YuanASI Technology Co., Ltd.)](https://yuanasi.com/en?utm_source=npm&utm_medium=package_readme&utm_campaign=open_multi_agent).

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -39,8 +39,9 @@
     "agent"
   ],
   "author": {
-    "name": "open-multi-agent",
-    "url": "https://github.com/open-multi-agent"
+    "name": "YuanASI (Shenzhen YuanASI Technology Co., Ltd.)",
+    "email": "co@yuanasi.com",
+    "url": "https://yuanasi.com"
   },
   "license": "MIT",
   "repository": {

--- a/packages/otel/LICENSE
+++ b/packages/otel/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) open-multi-agent contributors
+Copyright (c) Shenzhen YuanASI Technology Co., Ltd. and open-multi-agent contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -173,3 +173,9 @@ application chooses and configures its own OpenTelemetry SDK and OTLP (or
 other) exporter, which keeps this package's runtime surface to the OTel API and
 avoids eager OTLP imports, global-provider configuration, and a second
 SDK/exporter version matrix.
+
+## License
+
+MIT
+
+Maintained by [YuanASI (Shenzhen YuanASI Technology Co., Ltd.)](https://yuanasi.com/en?utm_source=npm&utm_medium=package_readme&utm_campaign=open_multi_agent).

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -35,8 +35,9 @@
     "llm"
   ],
   "author": {
-    "name": "open-multi-agent",
-    "url": "https://github.com/open-multi-agent"
+    "name": "YuanASI (Shenzhen YuanASI Technology Co., Ltd.)",
+    "email": "co@yuanasi.com",
+    "url": "https://yuanasi.com"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
- Updates the copyright line in LICENSE and the three package copies, adds a maintainer line to the package READMEs, and sets `author` in the published package.json files. CONTRIBUTORS.md and CHANGELOG.md updated accordingly.
- Copyrights of other contributors and the MIT license terms are unchanged.
