### PR TITLE
docs: add the run store to the unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,29 @@
 
 ## Unreleased
 
+### Added
+
+- Added an opt-in authoritative run store. `OrchestratorConfig.runStore` and
+  `RunTasksOptions.runStore` give a logical run a durable lifecycle record, an
+  execution lease, and a monotonically increasing fencing token, so one worker
+  at a time advances a run and a worker that was taken over cannot write after
+  the takeover. Ships the `RunStore` interface, the `MemoryStoreRunStore`
+  adapter over any `MemoryStore` with compare-and-set, and the `RunLedger` /
+  `RunLeaseHandle` surface for reading, cancelling, and resuming a run from
+  outside its worker.
+
 ### Changed
 
 - LICENSE now names Shenzhen YuanASI Technology Co., Ltd. alongside the
   open-multi-agent contributors, every package README closes with a maintainer
   line linking to yuanasi.com, and `author` in the three published package.json
   files points at YuanASI. The MIT terms are unchanged.
+- With a run store configured, execution-ownership and run-lifecycle writes fail
+  closed instead of following the best-effort semantics of checkpoint and
+  telemetry writes: a fenced-out checkpoint write never reaches the store, a
+  lost lease stops the run at the dispatch gate, and a worker that lost its
+  lease reports the fence failure rather than success. Runs with no run store
+  configured are unchanged.
 
 ## 1.18.0 - 2026-09-04
 


### PR DESCRIPTION
Follow-up to #587, which landed the run store without a changelog entry.

It meets both warranted tests in [RELEASING.md](https://github.com/open-multi-agent/open-multi-agent/blob/main/.github/RELEASING.md#what-earns-a-changelog-entry): it adds public exports and a new config field on `OrchestratorConfig` and `RunTasksOptions`, and it changes runtime behavior an unchanged caller can observe once a run store is configured.

Two entries under `## Unreleased`:

- **Added** — the opt-in run store itself: the durable lifecycle record, the execution lease and fencing token, the `RunStore` interface, the `MemoryStoreRunStore` adapter, and the `RunLedger` / `RunLeaseHandle` operator surface.
- **Changed** — the fail-closed semantics, which are the part an existing caller most needs to read before opting in: ownership and lifecycle writes no longer follow the best-effort rules that checkpoint and telemetry writes do.

Both entries say explicitly that runs with no run store configured are unaffected, so a reader scanning for breakage can stop at the first sentence.

`docs/run-store.md` is deliberately not mentioned: documentation under `docs/` does not ship in any tarball. The `packages/core/README.md` paragraph does ship and is covered by the Added entry.

Verified with `npm run test -w @open-multi-agent/release-bot` (59 pass), which includes the changelog-invariant suite that parses this file, plus `git diff --check`.
